### PR TITLE
perf: async shop parser with TTL cache (Unit 2)

### DIFF
--- a/handlers/users/shop.py
+++ b/handlers/users/shop.py
@@ -15,8 +15,8 @@ class ShopStates:
 
 @dp.message_handler(text=__("🛒 Магазин"))
 async def show_categories(message: types.Message):
-    products = get_products()
-    
+    products = await get_products()
+
     # Отримуємо унікальні категорії
     categories = set(product['category'] for product in products)
     
@@ -46,8 +46,8 @@ async def show_category_products(callback: types.CallbackQuery):
         await callback.answer(__("Категорія не знайдена"))
         return
     
-    products = [p for p in get_products() if p['category'] == category]
-    
+    products = [p for p in await get_products() if p['category'] == category]
+
     if not products:
         await callback.answer(__("В цій категорії зараз немає товарів"))
         return
@@ -139,8 +139,8 @@ async def navigate_products(callback: types.CallbackQuery):
         await callback.answer(__("Категорія не знайдена"))
         return
         
-    products = [p for p in get_products() if p['category'] == category]
-    
+    products = [p for p in await get_products() if p['category'] == category]
+
     if action == 'next':
         ShopStates.current_page[callback.from_user.id] += 1
     else:

--- a/utils/shop_parser.py
+++ b/utils/shop_parser.py
@@ -1,11 +1,24 @@
 import xml.etree.ElementTree as ET
-import requests
+import time
+
+import aiohttp
+
+_cache = None
+_cache_time = 0
+_CACHE_TTL = 600  # 10 minutes
 
 
-def get_products():
+async def get_products():
+    global _cache, _cache_time
+    now = time.time()
+    if _cache is not None and (now - _cache_time) < _CACHE_TTL:
+        return _cache
+
     url = "https://sunrise.co.ua/marketplace-integration/google-feed/27bd50b19dc9c0d7d1ed3c5a7278cc49?langId=3"
-    response = requests.get(url)
-    root = ET.fromstring(response.content)
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url) as response:
+            content = await response.read()
+    root = ET.fromstring(content)
 
     products = []
     for item in root.findall('.//item'):
@@ -30,4 +43,6 @@ def get_products():
             print(f"Помилка при парсингу товару: {e}")
             continue
 
+    _cache = products
+    _cache_time = now
     return products

--- a/utils/shop_parser.py
+++ b/utils/shop_parser.py
@@ -1,7 +1,10 @@
+import logging
 import xml.etree.ElementTree as ET
 import time
 
 import aiohttp
+
+logger = logging.getLogger(__name__)
 
 _cache = None
 _cache_time = 0
@@ -15,8 +18,10 @@ async def get_products():
         return _cache
 
     url = "https://sunrise.co.ua/marketplace-integration/google-feed/27bd50b19dc9c0d7d1ed3c5a7278cc49?langId=3"
-    async with aiohttp.ClientSession() as session:
+    timeout = aiohttp.ClientTimeout(total=30)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
         async with session.get(url) as response:
+            response.raise_for_status()
             content = await response.read()
     root = ET.fromstring(content)
 
@@ -40,7 +45,7 @@ async def get_products():
                 
             products.append(product)
         except AttributeError as e:
-            print(f"Помилка при парсингу товару: {e}")
+            logger.warning("Помилка при парсингу товару: %s", e)
             continue
 
     _cache = products


### PR DESCRIPTION
## Summary
- Replace synchronous `requests.get()` with `aiohttp` in `utils/shop_parser.py` to avoid blocking the event loop during product catalog fetches
- Add a 10-minute TTL cache for parsed product data, eliminating redundant HTTP requests on every shop interaction
- Update all three call sites in `handlers/users/shop.py` to `await` the now-async `get_products()`

## Test plan
- [ ] Verify shop categories load correctly via the bot
- [ ] Verify product navigation (next/prev) works
- [ ] Verify cache serves repeated requests within 10 minutes without re-fetching