### PR TITLE
perf: add language middleware TTL cache (Unit 4)

### DIFF
--- a/handlers/users/lang_change.py
+++ b/handlers/users/lang_change.py
@@ -5,6 +5,7 @@ from aiogram import types
 from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
 
 from middlewares import _, __
+from middlewares.language_middleware import invalidate_lang_cache
 from keyboards.default.buttons import lang_change
 
 
@@ -24,6 +25,7 @@ async def change_lang(message: types.Message):
 async def changed_lang(message: types.Message):
     await db.message(message.from_user.full_name, message.from_user.id, message.text, message.date)
     await db.set_lang(message.text[3:].lower(), message.from_user.id)
+    invalidate_lang_cache(message.from_user.id)
     if message.text[3:] == "UA":
         return_button = ReplyKeyboardMarkup(resize_keyboard=True, keyboard=[
             [

--- a/handlers/users/start.py
+++ b/handlers/users/start.py
@@ -1,5 +1,7 @@
 import logging
 
+logger = logging.getLogger(__name__)
+
 import asyncpg
 from aiogram import types
 from aiogram.dispatcher import FSMContext
@@ -12,6 +14,7 @@ from keyboards.inline.callback_datas import start_callback
 from keyboards.inline.start_keyboard import choice_lang
 from loader import dp, db
 from middlewares import _, __
+from middlewares.language_middleware import invalidate_lang_cache
 from states.get_client import Client, Request
 from utils.db_api import database
 from utils.format_number import format_number
@@ -60,6 +63,7 @@ async def get_phone_state(message: types.Message):
 async def lang_reply(call: CallbackQuery, state: FSMContext):
     await db.message(call.from_user.full_name, call.from_user.id, call.message.text, call.message.date)
     await db.set_lang(call.data[7:].lower(), call.from_user.id)
+    invalidate_lang_cache(call.from_user.id)
     await call.answer()
     msg = await call.message.edit_text(
         text=_(
@@ -96,7 +100,7 @@ async def ua_tel_get(message: types.Message, state: FSMContext):
         pass
     net_on = _("Увімкнено")
     net_off = _("Вимкнено")
-    print(database.data)
+    logger.debug("Billing data for user: %s", database.data)
     if len(database.data) > 0:
 
         net_pause = await database.check_net_pause(database.data[2])

--- a/middlewares/language_middleware.py
+++ b/middlewares/language_middleware.py
@@ -1,15 +1,30 @@
-from typing import Tuple, Any
+import time
+from typing import Tuple, Any, Dict, Optional
 
 from aiogram import types
 from aiogram.contrib.middlewares.i18n import I18nMiddleware
 from data.config import I18N_DOMAIN, LOCALES_DIR
 from loader import db, dp
 
+_lang_cache: Dict[int, Tuple[str, float]] = {}
+_LANG_CACHE_TTL = 300  # 5 minutes
+
 
 async def get_lang(user_id):
-    user = await db.select_lang(user_id)
-    if user:
-        return user
+    now = time.time()
+    cached = _lang_cache.get(user_id)
+    if cached and (now - cached[1]) < _LANG_CACHE_TTL:
+        return cached[0]
+
+    lang = await db.select_lang(user_id)
+    if lang:
+        _lang_cache[user_id] = (lang, now)
+        return lang
+    return None
+
+
+def invalidate_lang_cache(user_id: int):
+    _lang_cache.pop(user_id, None)
 
 
 class ACLMiddleware(I18nMiddleware):


### PR DESCRIPTION
## Summary
- Add an in-memory TTL cache (5 minutes) to the language middleware to avoid a PostgreSQL query on every Telegram update
- Cache stores per-user language preferences as `(language, timestamp)` tuples
- Add `invalidate_lang_cache()` function called after language changes in `lang_change.py` and `start.py` to ensure immediate effect

## Test plan
- [ ] Verify bot starts without import errors
- [ ] Change language and confirm it takes effect immediately (cache invalidation works)
- [ ] Confirm language persists across multiple messages without extra DB queries