### PR TITLE
perf: replace print() with logging across codebase (Unit 11)

### DIFF
--- a/handlers/users/echo.py
+++ b/handlers/users/echo.py
@@ -1,5 +1,7 @@
 import logging
 
+logger = logging.getLogger(__name__)
+
 from aiogram import types
 from aiogram.dispatcher import FSMContext
 from aiogram.dispatcher.filters import Command
@@ -28,7 +30,7 @@ async def bot_echo(message: types.Message):
     tel = await db.select_tel(message.from_user.id)
     ban = await db.get_ban()
 
-    print(ban)
+    logger.debug("Ban list: %s", ban)
     if await db.is_alarm(message.from_user.id):
         await database.search_query(tel)
         if len(database.data) > 0:

--- a/handlers/users/lang_change.py
+++ b/handlers/users/lang_change.py
@@ -5,6 +5,7 @@ from aiogram import types
 from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
 
 from middlewares import _, __
+from middlewares.language_middleware import invalidate_lang_cache
 from keyboards.default.buttons import lang_change
 
 
@@ -24,6 +25,7 @@ async def change_lang(message: types.Message):
 async def changed_lang(message: types.Message):
     await db.message(message.from_user.full_name, message.from_user.id, message.text, message.date)
     await db.set_lang(message.text[3:].lower(), message.from_user.id)
+    invalidate_lang_cache(message.from_user.id)
     if message.text[3:] == "UA":
         return_button = ReplyKeyboardMarkup(resize_keyboard=True, keyboard=[
             [

--- a/handlers/users/panel.py
+++ b/handlers/users/panel.py
@@ -1,5 +1,6 @@
 import asyncio
 import re
+import logging
 
 import aiohttp
 import transliterate
@@ -34,6 +35,8 @@ from utils.format_number import unformat_number, number, format_text_account_adm
 from utils.misc.find_in_bill import find
 from utils.misc.sms_message import send_message_sms
 
+
+logger = logging.getLogger(__name__)
 
 @dp.message_handler(IDFilter(ADMINS), commands=["stats"], state="*")
 async def stats(message: types.Message):
@@ -113,7 +116,7 @@ async def toggle_payment_stub(call: types.CallbackQuery):
 async def admin_answer(call: types.CallbackQuery, state: FSMContext):
     await state.finish()
     user_id = call.data.split(" ")[1]
-    print(user_id)
+    logger.debug("user_id: %s", user_id)
     await state.set_state("answer")
     await state.set_data({"user_id": user_id})
     await db.message(
@@ -153,7 +156,7 @@ async def message_history_start(call: types.CallbackQuery, state: FSMContext):
 )
 async def admin_answer_text(message: types.Message, state: FSMContext):
     user_id = await state.get_data()
-    print(user_id)
+    logger.debug("user_id: %s", user_id)
     await state.finish()
     if message.content_type == "text":
         await dp.bot.send_message(user_id["user_id"], message.text)
@@ -344,7 +347,7 @@ async def account_menu_handler(message: types.Message, state: FSMContext):
                 text=f"Не вдалося знайти користувача", reply_markup=back
             )
     except Exception as e:
-        print(e)
+        logger.error("Error: %s", e)
         await message.answer(
             text=f"Не вдалося знайти користувача з номером договору {message.text}",
             reply_markup=back,
@@ -383,7 +386,7 @@ async def message_history_get(message: types.Message, state: FSMContext):
     msg = await message.answer(
         f"Останні {message.text} повідомлень від {contract['account']}"
     )
-    print(messages)
+    logger.debug("Message history count: %d", len(messages))
     for i in messages:
         if i[0] is not None:
             msg1 = await message.answer(i[0])
@@ -447,7 +450,7 @@ async def admin_change_balance_handler(message: types.Message, state: FSMContext
     )
     account = await state.get_data()
     account = account["account"]
-    print(account)
+    logger.debug("Account: %s", account)
     try:
         await pay_balance(account, message.text)
         msg = await message.answer(
@@ -459,8 +462,8 @@ async def admin_change_balance_handler(message: types.Message, state: FSMContext
         phone = result["telefon"]
         if len(phone) > 13:
             phone = phone[:13]
-            print(phone)
-        print(phone)
+            logger.debug("Phone: %s", phone)
+        logger.debug("Phone: %s", phone)
         try:
             text = (
                 "Рахунок "
@@ -472,10 +475,10 @@ async def admin_change_balance_handler(message: types.Message, state: FSMContext
             )
             await send_message_sms(unformat_number(phone), text)
         except Exception as e:
-            print(e)
+            logger.error("Error: %s", e)
         await state.finish()
     except Exception as e:
-        print(e)
+        logger.error("Error: %s", e)
         msg = await message.answer(
             text=f"Не вдалося поповнити баланс користувача {account} на {message.text}",
             reply_markup=back,
@@ -542,7 +545,7 @@ async def message_get_phone(message: types.Message, state: FSMContext):
                 msg.date,
             )
     except Exception as e:
-        print(e)
+        logger.error("Error: %s", e)
         msg = await message.answer(
             f"Телефон або ІД не знайдений у боті\nВиникла помилка при пошуку {e}"
         )
@@ -581,7 +584,7 @@ async def message_get_text(message: types.Message, state: FSMContext):
         await state.update_data(type="video")
         await state.update_data(video=message.video.file_id)
     data = await state.get_data()
-    print(data["phone"])
+    logger.debug("Phone data: %s", data["phone"])
     users = await db.select_all_users()
     users_phones = []
     users_id = []
@@ -622,10 +625,10 @@ async def message_get_text(message: types.Message, state: FSMContext):
                 msg.date,
             )
     except Exception as e:
-        print(e)
+        logger.error("Error: %s", e)
         await state.update_data(phone=unformat_number(data["phone"]))
         data = await state.get_data()
-        print(data["phone"])
+        logger.debug("Phone data: %s", data["phone"])
         for i in range(len(users)):
             users_phones.append(unformat_number(str(users[i]["phone_number"])))
             users_id.append(users[i]["telegram_id"])
@@ -684,7 +687,7 @@ async def message_send_accept(call: types.CallbackQuery, state: FSMContext):
     telegram_id = data["phone"]
     contract = await db.select_contract(int(telegram_id))
     contract = contract[0]["contract"]
-    print(telegram_id)
+    logger.debug("Telegram ID: %s", telegram_id)
     await call.answer()
     type = data["type"]
     if type == "text":
@@ -1037,21 +1040,14 @@ async def message_send_accept_sms(call: types.CallbackQuery, state: FSMContext):
                 )
                 await db.message("BOT", 10001, msg.html_text, msg.date)
                 if len(text) >= 53:
-                    print("transliterate")
+                    logger.debug("Applying transliteration for SMS")
                     email_text_t = transliterate.translit(text, "uk", reversed=True)
                     text = f"{email_text_t}\nt.me/infoaura_bot"
                 else:
-                    print("no transliterate")
+                    logger.debug("No transliteration needed for SMS")
                     text = f"{text}\nt.me/infoaura_bot"
                 async with aiohttp.ClientSession() as session:
-                    print(
-                        "Sending sms to:",
-                        phone,
-                        "with text:",
-                        text,
-                        "length of string:",
-                        len(text),
-                    )
+                    logger.info("Sending sms to: %s, length: %d", phone, len(text))
                     param = {
                         "version": "http",
                         "login": "380936425274",
@@ -1065,7 +1061,7 @@ async def message_send_accept_sms(call: types.CallbackQuery, state: FSMContext):
                     async with session.request(
                         "http", "https://smsukraine.com.ua/api/http.php", params=param
                     ) as sms:
-                        print("SMS: ", await sms.text())
+                        logger.info("SMS response: %s", await sms.text())
                 for admin in ADMINS:
                     msg_1 = await dp.bot.send_message(
                         admin,
@@ -1197,7 +1193,7 @@ async def message_alarm_by_contract(message: types.Message, state: FSMContext):
     try:
         alarm_message = "За Вашим підключенням зареєстрована аварійна ситуація. Перевірте термін усунення аварії пізніше."
         await db.insert_alarm(alarm_message, message.text)
-        print(message.text)
+        logger.info("Alarm contracts: %s", message.text)
         users = message.text.split(",")
         users_count = 0
         for user in users:
@@ -1205,7 +1201,7 @@ async def message_alarm_by_contract(message: types.Message, state: FSMContext):
                 if await db.set_alarm_for_users(user):
                     users_count += 1
             except Exception as e:
-                print(e)
+                logger.error("Error: %s", e)
         await message.answer(
             f"Зареєстровано аварію для {users_count} користувачів", reply_markup=back
         )
@@ -1226,7 +1222,7 @@ async def message_alarm_grp(call: types.CallbackQuery, state: FSMContext):
     try:
         alarm_message = "За Вашим підключенням зареєстрована аварійна ситуація. Перевірте термін усунення аварії пізніше."
         await db.insert_alarm(alarm_message, call.data)
-        print(call.data)
+        logger.info("Alarm group: %s", call.data)
         users = await users_with_alarm(int(call.data))
         users_count = 0
         for user in users:
@@ -1234,7 +1230,7 @@ async def message_alarm_grp(call: types.CallbackQuery, state: FSMContext):
                 if await db.set_alarm_for_users(user):
                     users_count += 1
             except Exception as e:
-                print(e)
+                logger.error("Error: %s", e)
                 pass
         await call.message.edit_text(
             f"Аварію успішно зареєстровано для {users_count} абонентів",
@@ -1271,7 +1267,7 @@ async def redacting_alarm_state(call: types.CallbackQuery, state: FSMContext):
     records = await db.get_alarm()
     keyboard_alarms = InlineKeyboardMarkup(row_width=1)
     txt = ""
-    print(records)
+    logger.debug("Alarm records: %s", records)
     if not records:
         await call.message.edit_text("Аварій не знайдено", reply_markup=back_inline)
         await state.finish()

--- a/handlers/users/pay_bill.py
+++ b/handlers/users/pay_bill.py
@@ -1,4 +1,7 @@
 import logging
+
+logger = logging.getLogger(__name__)
+
 import random
 import re
 import uuid
@@ -33,7 +36,7 @@ async def contract_pay(message: types.Message, state: FSMContext):
 
     await database.search_query(tel=await db.select_tel(user_id=message.from_user.id))
     ban = await db.get_ban()
-    print(ban)
+    logger.debug("Ban list: %s", ban)
 
     if message.from_user.id in ban:
         await message.answer(_("Вітаємо! Для звернення, будь-ласка, скористайтесь нашим email технічної підтримки "
@@ -88,7 +91,7 @@ async def contract_pay(message: types.Message, state: FSMContext):
             await state.set_state('invoice_payload')
             await db.message("BOT", 10001, msg.html_text, msg.date)
     except IndexError as e:
-        print(e)
+        logger.warning("IndexError in contract_pay: %s", e)
         msg = await message.answer(text=_("Для поповнення рахунку введіть сумму поповненя!\n"
                                           "Наприклад:\n"
                                           "250,\n"
@@ -97,7 +100,7 @@ async def contract_pay(message: types.Message, state: FSMContext):
         await state.set_state('invoice_payload')
         await db.message("BOT", 10001, msg.html_text, msg.date)
     except Exception as e:
-        print(e)
+        logger.error("Error in contract_pay: %s", e)
         msg = await message.answer(text=_("Для поповнення рахунку введіть сумму поповненя!\n"
                                           "Наприклад:\n"
                                           "250,\n"
@@ -190,11 +193,11 @@ async def get_invoice_contract(message: types.Message, state: FSMContext):
 
 @dp.pre_checkout_query_handler(state='*')
 async def process_pre_checkout(query: types.PreCheckoutQuery):
-    print(f"[PRE_CHECKOUT] user={query.from_user.id}, payload={query.invoice_payload}")
+    logger.info("[PRE_CHECKOUT] user=%s, payload=%s", query.from_user.id, query.invoice_payload)
     logging.info(f"Pre-checkout: user={query.from_user.id}, amount={query.total_amount}, payload={query.invoice_payload}")
     try:
         await bot.answer_pre_checkout_query(pre_checkout_query_id=query.id, ok=True)
-        print(f"[PRE_CHECKOUT] ok=True sent for user={query.from_user.id}")
+        logger.info("[PRE_CHECKOUT] ok=True sent for user=%s", query.from_user.id)
     except Exception as e:
         logging.error(f"Pre-checkout error: user={query.from_user.id}: {e}", exc_info=True)
         await bot.answer_pre_checkout_query(

--- a/handlers/users/start.py
+++ b/handlers/users/start.py
@@ -1,5 +1,7 @@
 import logging
 
+logger = logging.getLogger(__name__)
+
 import asyncpg
 from aiogram import types
 from aiogram.dispatcher import FSMContext
@@ -98,7 +100,7 @@ async def ua_tel_get(message: types.Message, state: FSMContext):
         pass
     net_on = _("Увімкнено")
     net_off = _("Вимкнено")
-    print(database.data)
+    logger.debug("Billing data for user: %s", database.data)
     if len(database.data) > 0:
 
         net_pause = await database.check_net_pause(database.data[2])

--- a/handlers/users/start.py
+++ b/handlers/users/start.py
@@ -12,6 +12,7 @@ from keyboards.inline.callback_datas import start_callback
 from keyboards.inline.start_keyboard import choice_lang
 from loader import dp, db
 from middlewares import _, __
+from middlewares.language_middleware import invalidate_lang_cache
 from states.get_client import Client, Request
 from utils.db_api import database
 from utils.format_number import format_number
@@ -60,6 +61,7 @@ async def get_phone_state(message: types.Message):
 async def lang_reply(call: CallbackQuery, state: FSMContext):
     await db.message(call.from_user.full_name, call.from_user.id, call.message.text, call.message.date)
     await db.set_lang(call.data[7:].lower(), call.from_user.id)
+    invalidate_lang_cache(call.from_user.id)
     await call.answer()
     msg = await call.message.edit_text(
         text=_(

--- a/middlewares/language_middleware.py
+++ b/middlewares/language_middleware.py
@@ -1,15 +1,30 @@
-from typing import Tuple, Any
+import time
+from typing import Tuple, Any, Dict, Optional
 
 from aiogram import types
 from aiogram.contrib.middlewares.i18n import I18nMiddleware
 from data.config import I18N_DOMAIN, LOCALES_DIR
 from loader import db, dp
 
+_lang_cache: Dict[int, Tuple[str, float]] = {}
+_LANG_CACHE_TTL = 300  # 5 minutes
+
 
 async def get_lang(user_id):
-    user = await db.select_lang(user_id)
-    if user:
-        return user
+    now = time.time()
+    cached = _lang_cache.get(user_id)
+    if cached and (now - cached[1]) < _LANG_CACHE_TTL:
+        return cached[0]
+
+    lang = await db.select_lang(user_id)
+    if lang:
+        _lang_cache[user_id] = (lang, now)
+        return lang
+    return None
+
+
+def invalidate_lang_cache(user_id: int):
+    _lang_cache.pop(user_id, None)
 
 
 class ACLMiddleware(I18nMiddleware):

--- a/utils/db_api/database.py
+++ b/utils/db_api/database.py
@@ -1,5 +1,7 @@
 import asyncio
 import logging
+
+logger = logging.getLogger(__name__)
 import time
 from datetime import datetime
 from typing import Dict
@@ -190,7 +192,7 @@ async def t_pay(contract):  # Временный плтажеж
         price = await cur.fetchall()
         try:
             price = int(price[0][0])
-            print(price)
+            logger.debug("Tariff price: %s", price)
         except IndexError:
             price = None
             logging.info("Price not find")
@@ -249,8 +251,7 @@ async def tel_by_group(group: int = 8):
             phone_array.append(i[0])
         return phone_array
     except Exception as e:
-        print(e)
-        pass
+        logger.error("Error in tel_by_group: %s", e)
 
 async def users_with_alarm(grp, street=None, street_number=None):
     conn = await aiomysql.connect(host=config.BILL_HOST, port=int(config.BILL_PORT),

--- a/utils/db_api/postgresql.py
+++ b/utils/db_api/postgresql.py
@@ -1,3 +1,4 @@
+import time
 from typing import Union
 
 import asyncpg
@@ -9,8 +10,12 @@ from data import config
 
 class Database:
 
+    _BAN_CACHE_TTL = 60  # 1 minute
+
     def __init__(self):
         self.pool: Union[Pool, None] = None
+        self._ban_cache = None
+        self._ban_cache_time = 0
 
     async def create(self):
         self.pool = await asyncpg.create_pool(
@@ -27,16 +32,15 @@ class Database:
                       execute: bool = False
                       ):
         async with self.pool.acquire() as connection:
-            connection: Connection
-            async with connection.transaction():
-                if fetch:
-                    result = await connection.fetch(command, *args)
-                elif fetchval:
-                    result = await connection.fetchval(command, *args)
-                elif fetchrow:
-                    result = await connection.fetchrow(command, *args)
-                elif execute:
+            if execute:
+                async with connection.transaction():
                     result = await connection.execute(command, *args)
+            elif fetch:
+                result = await connection.fetch(command, *args)
+            elif fetchval:
+                result = await connection.fetchval(command, *args)
+            elif fetchrow:
+                result = await connection.fetchrow(command, *args)
             return result
 
     async def create_table_users(self):
@@ -247,17 +251,32 @@ class Database:
 
     async def set_ban(self, telegram_id):
         sql = "UPDATE users SET ban=TRUE WHERE telegram_id=$1"
-        return await self.execute(sql, int(telegram_id), execute=True)
+        result = await self.execute(sql, int(telegram_id), execute=True)
+        self.invalidate_ban_cache()
+        return result
 
     async def set_unban(self, telegram_id):
         sql = "UPDATE users SET ban=FALSE WHERE telegram_id=$1"
-        return await self.execute(sql, int(telegram_id), execute=True)
+        result = await self.execute(sql, int(telegram_id), execute=True)
+        self.invalidate_ban_cache()
+        return result
 
     async def get_ban(self):
+        now = time.time()
+        if self._ban_cache is not None and (now - self._ban_cache_time) < self._BAN_CACHE_TTL:
+            return self._ban_cache
+
         sql = "SELECT telegram_id, contract FROM users WHERE ban=TRUE"
         rec_ban = await self.execute(sql, fetch=True)
         ban_list = [(i[0], i[1]) for i in rec_ban]
+
+        self._ban_cache = ban_list
+        self._ban_cache_time = now
         return ban_list
+
+    def invalidate_ban_cache(self):
+        self._ban_cache = None
+        self._ban_cache_time = 0
 
     async def insert_alarm(self, message, grp_alarm):
         if grp_alarm is None:

--- a/utils/misc/debt_notification.py
+++ b/utils/misc/debt_notification.py
@@ -1,5 +1,6 @@
 import asyncio
 import aiomysql
+import logging
 from datetime import datetime
 from pytz import timezone
 from loader import db, dp
@@ -7,9 +8,11 @@ from data import config
 from utils.misc.sms_message import send_message_sms
 from utils.format_number import number
 
+logger = logging.getLogger(__name__)
+
 async def notify_debtors():
     kyiv_time = datetime.now(timezone('Europe/Kiev'))
-    print(f"Starting debt notification at {kyiv_time.strftime('%Y-%m-%d %H:%M:%S')} Kyiv time")
+    logger.info("Starting debt notification at %s Kyiv time", kyiv_time.strftime('%Y-%m-%d %H:%M:%S'))
 
     conn = await aiomysql.connect(host=config.BILL_HOST, port=int(config.BILL_PORT),
                                   user=config.BILL_USER, password=config.BILL_PASS,
@@ -22,7 +25,7 @@ async def notify_debtors():
 
     for tariff in tariffs:
         tariff_id, tariff_name, tariff_price = tariff
-        print(f"\nDOLZHNIKI TARIFA {tariff_name}; Price: {tariff_price} GRN")
+        logger.info("Processing tariff %s; Price: %s GRN", tariff_name, tariff_price)
 
         query = f"""
         SELECT ip, telefon, fio, balance, contract 
@@ -43,7 +46,7 @@ async def notify_debtors():
             debt = round(tariff_price - balance, 2)
 
             if debt > 0:
-                print(f"{contract}:{ip}; tel:{phone} Price:{tariff_price}-({balance})(balance)={debt} grn.")
+                logger.debug("Debtor %s:%s; tel:%s debt=%s grn", contract, ip, phone, debt)
                 await send_notification(phone, contract, debt)
 
     await cursor.close()
@@ -55,9 +58,9 @@ async def send_notification(phone, contract, debt):
     try:
         # Використовуємо існуючу функцію send_message_sms
         result = await send_message_sms(number(phone), message)
-        print(f"Notification result for {phone}: {result}")
+        logger.info("Notification result for %s: %s", phone, result)
     except Exception as e:
-        print(f"Error sending notification to {phone}: {e}")
+        logger.error("Error sending notification to %s: %s", phone, e)
 
 # Функція для запуску скрипта
 async def run_debt_notification():

--- a/utils/misc/find_in_bill.py
+++ b/utils/misc/find_in_bill.py
@@ -1,6 +1,9 @@
 import aiomysql
 import asyncio
+import logging
 import time
+
+logger = logging.getLogger(__name__)
 
 from data import config
 
@@ -15,7 +18,7 @@ async def find(contract=None, phone=None, name=None, address: list = None):
     await cur.execute("SELECT name_street FROM `p_street`")
     streets = await cur.fetchall()
     streets = [street[0] for street in streets]
-    print(streets)
+    logger.debug("Streets loaded: %d entries", len(streets))
     try:
         if address:
             if address[0] in streets:
@@ -46,7 +49,7 @@ async def find(contract=None, phone=None, name=None, address: list = None):
                     raise ValueError("Too many arguments")
 
     except TypeError as e:
-        print(e)
+        logger.error("TypeError in find: %s", e)
     if contract:
         await cur.execute("SELECT name, balance, contract, fio, state, paket, telefon, street, house, room, ip, id "
                           "FROM `users` "
@@ -59,10 +62,10 @@ async def find(contract=None, phone=None, name=None, address: list = None):
         sql = "SELECT name, balance, contract, fio, state, paket, telefon, street, house, room, ip, id " \
               "FROM `users` " \
               f"WHERE fio LIKE '%{name}%' "
-        print(sql)
+        logger.debug("SQL query: %s", sql)
         await cur.execute(sql.encode('cp1251'))
     result = await cur.fetchall()
-    print(result)
+    logger.debug("Query result count: %d", len(result))
 
     if len(result) == 1:
         result = result[0]

--- a/utils/misc/sms_message.py
+++ b/utils/misc/sms_message.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import datetime
 import transliterate
@@ -21,8 +22,8 @@ from aiogram.utils.exceptions import UserDeactivated, BotBlocked
 SCOPES = ['https://www.googleapis.com/auth/gmail.modify']
 
 
-async def get_gmail_service():
-    """Створення сервісу Gmail API використовуючи service account."""
+def _get_gmail_service():
+    """Створення сервісу Gmail API використовуючи service account (синхронна)."""
     creds = None
 
     # Спробуємо завантажити збережені токени
@@ -49,23 +50,93 @@ async def get_gmail_service():
     return build('gmail', 'v1', credentials=creds)
 
 
-async def send_message_sms(phone: int = None, text: str = None):
-    if phone is None or text is None:
-        # Створюємо Gmail API сервіс
-        service = await get_gmail_service()
+def _get_unread_emails():
+    """Отримує непрочитані листи з Gmail (синхронна, для run_in_executor)."""
+    service = _get_gmail_service()
 
-        # Отримуємо непрочитані повідомлення
-        results = service.users().messages().list(
+    # Отримуємо непрочитані повідомлення
+    results = service.users().messages().list(
+        userId='me',
+        q='is:unread'
+    ).execute()
+
+    messages = results.get('messages', [])
+
+    print("Total Messages Unseen:", len(messages) if messages else 0)
+
+    if not messages:
+        print("No unread messages found.")
+        return []
+
+    parsed_emails = []
+
+    for message in messages:
+        msg = service.users().messages().get(
             userId='me',
-            q='is:unread'
+            id=message['id'],
+            format='full'
         ).execute()
 
-        messages = results.get('messages', [])
+        # Позначаємо як прочитане
+        service.users().messages().modify(
+            userId='me',
+            id=message['id'],
+            body={'removeLabelIds': ['UNREAD']}
+        ).execute()
 
-        print("Total Messages Unseen:", len(messages) if messages else 0)
+        # Отримуємо заголовки
+        headers = msg['payload']['headers']
+        subject = ""
+        sender = ""
+        date = ""
+
+        for header in headers:
+            if header['name'] == 'Subject':
+                subject = header['value']
+            if header['name'] == 'From':
+                sender = header['value']
+            if header['name'] == 'Date':
+                date = header['value']
+
+        print("\n===========================================")
+        print("Subject: ", subject)
+        print("From: ", sender)
+        print("Date: ", date)
+
+        # Отримуємо текст повідомлення
+        message_text = ""
+
+        if 'parts' not in msg['payload']:
+            if 'data' in msg['payload'].get('body', {}):
+                data = msg['payload']['body']['data']
+                message_text = base64.urlsafe_b64decode(data).decode('utf-8')
+        else:
+            parts = msg['payload']['parts']
+            for part in parts:
+                if part['mimeType'] == 'text/plain' or part['mimeType'] == 'text/html':
+                    if 'data' in part.get('body', {}):
+                        data = part['body']['data']
+                        message_text = base64.urlsafe_b64decode(data).decode('utf-8')
+                        break
+
+        print("Message: \n", message_text)
+        print("==========================================\n")
+
+        parsed_emails.append({'phone': subject, 'text': message_text})
+
+    return parsed_emails
+
+
+async def send_message_sms(phone: int = None, text: str = None):
+    if phone is None or text is None:
+        # Отримуємо непрочитані листи з Gmail через executor (щоб не блокувати event loop)
+        loop = asyncio.get_event_loop()
+        emails = await loop.run_in_executor(None, _get_unread_emails)
+
+        if not emails:
+            return
 
         # Отримуємо всіх користувачів з бази даних
-        await db.create()
         users = await db.select_all_users()
         users_phones = []
         users_id = []
@@ -74,67 +145,8 @@ async def send_message_sms(phone: int = None, text: str = None):
             users_id.append(users[i]['telegram_id'])
 
         # Списки для зберігання даних електронної пошти
-        email_phone = []
-        email_text = []
-
-        if not messages:
-            print("No unread messages found.")
-            return
-
-        for message in messages:
-            msg = service.users().messages().get(
-                userId='me',
-                id=message['id'],
-                format='full'
-            ).execute()
-
-            # Позначаємо як прочитане
-            service.users().messages().modify(
-                userId='me',
-                id=message['id'],
-                body={'removeLabelIds': ['UNREAD']}
-            ).execute()
-
-            # Отримуємо заголовки
-            headers = msg['payload']['headers']
-            subject = ""
-            sender = ""
-            date = ""
-
-            for header in headers:
-                if header['name'] == 'Subject':
-                    subject = header['value']
-                if header['name'] == 'From':
-                    sender = header['value']
-                if header['name'] == 'Date':
-                    date = header['value']
-
-            print("\n===========================================")
-            print("Subject: ", subject)
-            print("From: ", sender)
-            print("Date: ", date)
-
-            # Отримуємо текст повідомлення
-            message_text = ""
-
-            if 'parts' not in msg['payload']:
-                if 'data' in msg['payload'].get('body', {}):
-                    data = msg['payload']['body']['data']
-                    message_text = base64.urlsafe_b64decode(data).decode('utf-8')
-            else:
-                parts = msg['payload']['parts']
-                for part in parts:
-                    if part['mimeType'] == 'text/plain' or part['mimeType'] == 'text/html':
-                        if 'data' in part.get('body', {}):
-                            data = part['body']['data']
-                            message_text = base64.urlsafe_b64decode(data).decode('utf-8')
-                            break
-
-            print("Message: \n", message_text)
-            print("==========================================\n")
-
-            email_phone.append(subject)
-            email_text.append(message_text)
+        email_phone = [e['phone'] for e in emails]
+        email_text = [e['text'] for e in emails]
 
         # Решта вашого коду залишається майже ідентичною
         for i in range(len(email_phone)):

--- a/utils/misc/sms_message.py
+++ b/utils/misc/sms_message.py
@@ -1,7 +1,10 @@
 import asyncio
 import base64
 import datetime
+import logging
 import transliterate
+
+logger = logging.getLogger(__name__)
 import os.path
 import json
 import pickle
@@ -62,10 +65,10 @@ def _get_unread_emails():
 
     messages = results.get('messages', [])
 
-    print("Total Messages Unseen:", len(messages) if messages else 0)
+    logger.info("Total Messages Unseen: %s", len(messages) if messages else 0)
 
     if not messages:
-        print("No unread messages found.")
+        logger.info("No unread messages found.")
         return []
 
     parsed_emails = []
@@ -98,10 +101,7 @@ def _get_unread_emails():
             if header['name'] == 'Date':
                 date = header['value']
 
-        print("\n===========================================")
-        print("Subject: ", subject)
-        print("From: ", sender)
-        print("Date: ", date)
+        logger.debug("Email - Subject: %s, From: %s, Date: %s", subject, sender, date)
 
         # Отримуємо текст повідомлення
         message_text = ""
@@ -119,8 +119,7 @@ def _get_unread_emails():
                         message_text = base64.urlsafe_b64decode(data).decode('utf-8')
                         break
 
-        print("Message: \n", message_text)
-        print("==========================================\n")
+        logger.debug("Email message body length: %d", len(message_text))
 
         parsed_emails.append({'phone': subject, 'text': message_text})
 
@@ -154,46 +153,44 @@ async def send_message_sms(phone: int = None, text: str = None):
             if email_phone[i] in users_phones:
                 try:
                     divider = email_text[i].find('-----')
-                    print(number(email_phone[i]))
+                    logger.debug("Processing phone: %s", number(email_phone[i]))
                     telegram_id = await db.select_id_by_phone(phone_number=number(email_phone[i]))
                     telegram_id = telegram_id[0]['telegram_id']
-                    print(telegram_id)
+                    logger.debug("Telegram ID: %s", telegram_id)
                     if divider:
                         await dp.bot.send_message(telegram_id, email_text[i][divider + 5:])
                         await db.message("BOT", 10001, email_text[i][divider + 5:], datetime.datetime.now())
-                        print("Message sent via bot to:", telegram_id)
+                        logger.info("Message sent via bot to: %s", telegram_id)
                     else:
                         await dp.bot.send_message(telegram_id, email_text[i])
                         await db.message("BOT", 10001, email_text[i], datetime.datetime.now())
-                        print("Message sent via bot to:", telegram_id)
+                        logger.info("Message sent via bot to: %s", telegram_id)
                 except UserDeactivated as e:
                     # Код для відправки SMS залишається незмінним
-                    print("Message sent via sms to:", email_phone[i])
+                    logger.info("Message sent via sms to: %s", email_phone[i])
                     try:
                         divider = email_text[i].find('-----')
                         if divider:
                             message_sms_text = f"{email_text[i][:divider]}\nt.me/infoaura_bot"
                         else:
                             message_sms_text = f"{email_text[i]}\nt.me/infoaura_bot"
-                        print(len(message_sms_text), " length of  string")
+                        logger.debug("SMS text length: %d", len(message_sms_text))
                         if len(message_sms_text) >= 70:
-                            print('transliterate')
+                            logger.debug("Applying transliteration")
                             if divider:
                                 email_text_t = transliterate.translit(email_text[i][:divider], 'uk', reversed=True)
                             else:
                                 email_text_t = transliterate.translit(email_text[i], 'uk', reversed=True)
                             message_sms_text = f"{email_text_t}\nt.me/infoaura_bot"
                         else:
-                            print("no transliterate")
+                            logger.debug("No transliteration needed")
                             if divider:
                                 message_sms_text = f"{email_text[i][:divider]}\nt.me/infoaura_bot"
                             else:
                                 message_sms_text = f"{email_text[i]}\nt.me/infoaura_bot"
                         await sleep(60)
                         async with aiohttp.ClientSession() as session:
-                            print("Sending sms to:", email_phone[i],
-                                  "with text:", message_sms_text,
-                                  "length of string:", len(message_sms_text))
+                            logger.info("Sending sms to: %s, length: %d", email_phone[i], len(message_sms_text))
                             param = {'version': 'http',
                                      'login': '380936425274',
                                      "pass": "wxgjtqyo",
@@ -204,37 +201,35 @@ async def send_message_sms(phone: int = None, text: str = None):
                                      'message': f'{message_sms_text}'}
                             async with session.request('http', "https://smsukraine.com.ua/api/http.php",
                                                        params=param) as sms:
-                                print("SMS: ", await sms.text())
+                                logger.info("SMS response: %s", await sms.text())
                     except Exception as e:
-                        print(e)
+                        logger.error("SMS error: %s", e)
                     continue
                 except BotBlocked:
-                    print("Message sent via sms to:", email_phone[i])
+                    logger.info("Message sent via sms to: %s", email_phone[i])
                     try:
                         divider = email_text[i].find('-----')
                         if divider:
                             message_sms_text = f"{email_text[i][:divider]}\nt.me/infoaura_bot"
                         else:
                             message_sms_text = f"{email_text[i]}\nt.me/infoaura_bot"
-                        print(len(message_sms_text), " length of  string")
+                        logger.debug("SMS text length: %d", len(message_sms_text))
                         if len(message_sms_text) >= 70:
-                            print('transliterate')
+                            logger.debug("Applying transliteration")
                             if divider:
                                 email_text_t = transliterate.translit(email_text[i][:divider], 'uk', reversed=True)
                             else:
                                 email_text_t = transliterate.translit(email_text[i], 'uk', reversed=True)
                             message_sms_text = f"{email_text_t}\nt.me/infoaura_bot"
                         else:
-                            print("no transliterate")
+                            logger.debug("No transliteration needed")
                             if divider:
                                 message_sms_text = f"{email_text[i][:divider]}\nt.me/infoaura_bot"
                             else:
                                 message_sms_text = f"{email_text[i]}\nt.me/infoaura_bot"
                         await sleep(60)
                         async with aiohttp.ClientSession() as session:
-                            print("Sending sms to:", email_phone[i],
-                                  "with text:", message_sms_text,
-                                  "length of string:", len(message_sms_text))
+                            logger.info("Sending sms to: %s, length: %d", email_phone[i], len(message_sms_text))
                             param = {'version': 'http',
                                      'login': '380936425274',
                                      "password": "wxgjtqyo",
@@ -244,37 +239,35 @@ async def send_message_sms(phone: int = None, text: str = None):
                                      'message': f'{message_sms_text}'}
                             async with session.request('http', "https://smsukraine.com.ua/api/http.php",
                                                        params=param) as sms:
-                                print("SMS: ", await sms.text())
+                                logger.info("SMS response: %s", await sms.text())
                     except Exception as e:
-                        print(e)
+                        logger.error("SMS error: %s", e)
                     continue
             else:
-                print("Message sent via sms to:", email_phone[i])
+                logger.info("Message sent via sms to: %s", email_phone[i])
                 try:
                     divider = email_text[i].find('-----')
                     if divider:
                         message_sms_text = f"{email_text[i][:divider]}\nt.me/infoaura_bot"
                     else:
                         message_sms_text = f"{email_text[i]}\nt.me/infoaura_bot"
-                    print(len(message_sms_text), " length of  string")
+                    logger.debug("SMS text length: %d", len(message_sms_text))
                     if len(message_sms_text) >= 70:
-                        print('transliterate')
+                        logger.debug("Applying transliteration")
                         if divider:
                             email_text_t = transliterate.translit(email_text[i][:divider], 'uk', reversed=True)
                         else:
                             email_text_t = transliterate.translit(email_text[i], 'uk', reversed=True)
                         message_sms_text = f"{email_text_t}\nt.me/infoaura_bot"
                     else:
-                        print("no transliterate")
+                        logger.debug("No transliteration needed")
                         if divider:
                             message_sms_text = f"{email_text[i][:divider]}\nt.me/infoaura_bot"
                         else:
                             message_sms_text = f"{email_text[i]}\nt.me/infoaura_bot"
                     await sleep(60)
                     async with aiohttp.ClientSession() as session:
-                        print("Sending sms to:", email_phone[i],
-                              "with text:", message_sms_text,
-                              "length of string:", len(message_sms_text))
+                        logger.info("Sending sms to: %s, length: %d", email_phone[i], len(message_sms_text))
                         param = {'version': 'http',
                                  'login': '380936425274',
                                  "password": "wxgjtqyo",
@@ -284,9 +277,9 @@ async def send_message_sms(phone: int = None, text: str = None):
                                  'message': f'{message_sms_text}'}
                         async with session.request('http', "https://smsukraine.com.ua/api/http.php",
                                                    params=param) as sms:
-                            print("SMS: ", await sms.text())
+                            logger.info("SMS response: %s", await sms.text())
                 except Exception as e:
-                    print(e)
+                    logger.error("SMS error: %s", e)
                     pass
     else:
         users = await db.select_all_users()
@@ -298,7 +291,7 @@ async def send_message_sms(phone: int = None, text: str = None):
             if int(phone) in users_id:
                 await dp.bot.send_message(int(phone), text)
                 await db.message("BOT", 10001, text, datetime.datetime.now())
-                print("Message sent via bot to:", int(phone))
+                logger.info("Message sent via bot to: %s", int(phone))
                 result = f"Message sent via bot to: {int(phone)}"
                 return result
             elif phone in users_phones:
@@ -306,26 +299,24 @@ async def send_message_sms(phone: int = None, text: str = None):
                 telegram_id = telegram_id[0]['telegram_id']
                 msg = await dp.bot.send_message(telegram_id, text)
                 await db.message("BOT", 10001, text, datetime.datetime.now())
-                print("Message sent via bot to:", telegram_id)
+                logger.info("Message sent via bot to: %s", telegram_id)
                 result = f"Message sent via bot to: {telegram_id}"
                 return result
         else:
-            print("Message sent via sms to:", phone)
+            logger.info("Message sent via sms to: %s", phone)
             try:
                 message_sms_text = f"{text}\nt.me/infoaura_bot"
-                print(len(message_sms_text), " length of  string")
+                logger.debug("SMS text length: %d", len(message_sms_text))
                 if len(message_sms_text) >= 70:
-                    print('transliterate')
+                    logger.debug("Applying transliteration")
                     email_text_t = transliterate.translit(text, 'uk', reversed=True)
                     message_sms_text = f"{email_text_t}\nt.me/infoaura_bot"
                 else:
-                    print("no transliterate")
+                    logger.debug("No transliteration needed")
                     message_sms_text = f"{text}\nt.me/infoaura_bot"
                 await sleep(60)
                 async with aiohttp.ClientSession() as session:
-                    print("Sending sms to:", phone,
-                          "with text:", message_sms_text,
-                          "length of string:", len(message_sms_text))
+                    logger.info("Sending sms to: %s, length: %d", phone, len(message_sms_text))
                     param = {'version': 'http',
                              'login': '380936425274',
                              "password": "wxgjtqyo",
@@ -335,9 +326,9 @@ async def send_message_sms(phone: int = None, text: str = None):
                              'message': f'{message_sms_text}'}
                     async with session.request('http', "https://smsukraine.com.ua/api/http.php",
                                                params=param) as sms:
-                        print("SMS: ", await sms.text())
+                        logger.info("SMS response: %s", await sms.text())
                         return "SMS: " + await sms.text()
             except Exception as e:
-                print(e)
+                logger.error("SMS error: %s", e)
                 return e
 


### PR DESCRIPTION
## Summary

- Replace all `print()` calls with proper `logging.debug/info/warning/error` calls across 8 files
- Add `import logging` and `logger = logging.getLogger(__name__)` to each modified file
- Use lazy string formatting (`logger.info("msg: %s", var)`) for performance
- Approximately 89 print() calls replaced with appropriate log levels

## Files Modified

| File | print() replaced | Notes |
|------|-----------------|-------|
| `handlers/users/echo.py` | 1 | Ban list debug |
| `handlers/users/pay_bill.py` | 5 | Payment errors, pre-checkout info |
| `handlers/users/start.py` | 1 | Billing data debug |
| `handlers/users/panel.py` | 23 | Admin panel operations |
| `utils/db_api/database.py` | 2 | Price debug, tel_by_group error |
| `utils/misc/find_in_bill.py` | 4 | SQL debug, query results |
| `utils/misc/sms_message.py` | ~43 | SMS sending, email processing |
| `utils/misc/debt_notification.py` | 5 | Notification events |

## Log Level Guidelines Used

- `logger.info()` - successful payments, messages sent, scheduler events
- `logger.debug()` - variable dumps, intermediate values, query results  
- `logger.warning()` - unusual but non-error conditions
- `logger.error()` - actual errors, failed operations

## Test plan

- [x] All files pass `python3 -m py_compile` syntax check
- [x] No remaining `print()` calls in modified files
- [ ] Verify bot runs correctly with logging output