### PR TITLE
perf: add language middleware TTL cache (Unit 4)

### DIFF
--- a/handlers/users/lang_change.py
+++ b/handlers/users/lang_change.py
@@ -5,6 +5,7 @@ from aiogram import types
 from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
 
 from middlewares import _, __
+from middlewares.language_middleware import invalidate_lang_cache
 from keyboards.default.buttons import lang_change
 
 
@@ -24,6 +25,7 @@ async def change_lang(message: types.Message):
 async def changed_lang(message: types.Message):
     await db.message(message.from_user.full_name, message.from_user.id, message.text, message.date)
     await db.set_lang(message.text[3:].lower(), message.from_user.id)
+    invalidate_lang_cache(message.from_user.id)
     if message.text[3:] == "UA":
         return_button = ReplyKeyboardMarkup(resize_keyboard=True, keyboard=[
             [

--- a/middlewares/language_middleware.py
+++ b/middlewares/language_middleware.py
@@ -1,15 +1,30 @@
-from typing import Tuple, Any
+import time
+from typing import Tuple, Any, Dict, Optional
 
 from aiogram import types
 from aiogram.contrib.middlewares.i18n import I18nMiddleware
 from data.config import I18N_DOMAIN, LOCALES_DIR
 from loader import db, dp
 
+_lang_cache: Dict[int, Tuple[str, float]] = {}
+_LANG_CACHE_TTL = 300  # 5 minutes
+
 
 async def get_lang(user_id):
-    user = await db.select_lang(user_id)
-    if user:
-        return user
+    now = time.time()
+    cached = _lang_cache.get(user_id)
+    if cached and (now - cached[1]) < _LANG_CACHE_TTL:
+        return cached[0]
+
+    lang = await db.select_lang(user_id)
+    if lang:
+        _lang_cache[user_id] = (lang, now)
+        return lang
+    return None
+
+
+def invalidate_lang_cache(user_id: int):
+    _lang_cache.pop(user_id, None)
 
 
 class ACLMiddleware(I18nMiddleware):


### PR DESCRIPTION
## Summary
- Add 5-minute TTL cache for user language lookups in ACLMiddleware
- Avoids PostgreSQL query on every Telegram update
- Cache invalidated on language change

Clean cherry-pick of Unit 4 changes only (original PR #10 had start.py bloat).