### PR TITLE
perf: Units 9, 10 - admin parallel + streets cache (Bug 2 fix)

### DIFF
--- a/handlers/users/echo.py
+++ b/handlers/users/echo.py
@@ -70,7 +70,7 @@ async def bot_echo(message: types.Message):
                                f"Текст сообщения: {message.text}\n"
                                f"Телефон: {tel}\n"
                                f"Номер договору: {database.data[2]}\n")
-                await asyncio.gather(
+                results = await asyncio.gather(
                     *[dp.bot.send_message(chat_id=admin, text=notify_text,
                                           parse_mode='HTML', reply_markup=answer_reply)
                       for admin in ADMINS],
@@ -81,7 +81,7 @@ async def bot_echo(message: types.Message):
                                   f"Текст сообщения: {message.caption}\n"
                                   f"Телефон: {tel}\n"
                                   f"Номер договору: {database.data[2]}\n")
-                await asyncio.gather(
+                results = await asyncio.gather(
                     *[dp.bot.send_photo(chat_id=admin, photo=message.photo[-1].file_id,
                                         caption=notify_caption, parse_mode='HTML',
                                         reply_markup=answer_reply)
@@ -93,7 +93,7 @@ async def bot_echo(message: types.Message):
                                   f" {message.from_user.full_name}\n"
                                   f"Телефон: {tel}\n"
                                   f"Номер договору: {database.data[2]}\n")
-                await asyncio.gather(
+                results = await asyncio.gather(
                     *[dp.bot.send_document(chat_id=admin, document=message.document.file_id,
                                            caption=notify_caption, parse_mode='HTML',
                                            reply_markup=answer_reply)
@@ -105,15 +105,22 @@ async def bot_echo(message: types.Message):
                                   f" {message.from_user.full_name}\n"
                                   f"Телефон: {tel}\n"
                                   f"Номер договору: {database.data[2]}\n")
-                await asyncio.gather(
+                results = await asyncio.gather(
                     *[dp.bot.send_video(chat_id=admin, video=message.video.file_id,
                                         caption=notify_caption, parse_mode='HTML',
                                         reply_markup=answer_reply)
                       for admin in ADMINS],
                     return_exceptions=True
                 )
+            else:
+                results = []
+            for result in results:
+                if isinstance(result, Exception):
+                    logger.error("Failed to notify admin: %s", result)
+                elif hasattr(result, 'html_text'):
+                    await db.message("BOT", 10001, result.html_text, result.date)
         except Exception as err:
-            logging.exception(err)
+            logger.exception(err)
     else:
         await database.search_query(tel)
         if len(database.data) > 0:
@@ -141,7 +148,7 @@ async def bot_echo(message: types.Message):
                 notify_text = (f"Сообщения от пользователя: {message.from_user.full_name}\n"
                                f"Текст сообщения: {message.text}\n"
                                f"Пользователь без телефона")
-                await asyncio.gather(
+                results = await asyncio.gather(
                     *[dp.bot.send_message(chat_id=admin, text=notify_text,
                                           parse_mode='HTML', reply_markup=answer_reply)
                       for admin in ADMINS],
@@ -150,7 +157,7 @@ async def bot_echo(message: types.Message):
             elif message.content_type == 'photo':
                 notify_caption = (f"Сообщения от пользователя: {message.from_user.full_name}\n"
                                   f"Пользователь без телефона")
-                await asyncio.gather(
+                results = await asyncio.gather(
                     *[dp.bot.send_photo(chat_id=admin, photo=message.photo[-1].file_id,
                                         caption=notify_caption, parse_mode='HTML',
                                         reply_markup=answer_reply)
@@ -161,7 +168,7 @@ async def bot_echo(message: types.Message):
                 notify_caption = (f"Сообщения от пользователя:"
                                   f" {message.from_user.full_name}\n"
                                   f"Пользователь без телефона")
-                await asyncio.gather(
+                results = await asyncio.gather(
                     *[dp.bot.send_document(chat_id=admin, document=message.document.file_id,
                                            caption=notify_caption, reply_markup=answer_reply)
                       for admin in ADMINS],
@@ -171,15 +178,22 @@ async def bot_echo(message: types.Message):
                 notify_caption = (f"Сообщения от пользователя:"
                                   f" {message.from_user.full_name}\n"
                                   f"Пользователь без телефона")
-                await asyncio.gather(
+                results = await asyncio.gather(
                     *[dp.bot.send_video(chat_id=admin, video=message.video.file_id,
                                         caption=notify_caption, parse_mode='HTML',
                                         reply_markup=answer_reply)
                       for admin in ADMINS],
                     return_exceptions=True
                 )
+            else:
+                results = []
+            for result in results:
+                if isinstance(result, Exception):
+                    logger.error("Failed to notify admin: %s", result)
+                elif hasattr(result, 'html_text'):
+                    await db.message("BOT", 10001, result.html_text, result.date)
         except Exception as err:
-            logging.exception(err)
+            logger.exception(err)
 
 # Эхо хендлер, куда летят ВСЕ сообщения с указанным состоянием
 # @dp.message_handler(state="*", content_types=types.ContentTypes.ANY)

--- a/handlers/users/echo.py
+++ b/handlers/users/echo.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 
 logger = logging.getLogger(__name__)
@@ -61,49 +62,56 @@ async def bot_echo(message: types.Message):
                 reply_markup=unknown_request_button)
             await db.message("BOT", 10001, msg.html_text, msg.date)
         try:
-            for admin in ADMINS:
-                answer_reply = InlineKeyboardMarkup()
-                answer_reply.add(InlineKeyboardButton(text="Відповісти",
-                                                      callback_data=f"answer {message.from_user.id}"))
-                if message.content_type == 'text':
-                    msg = await dp.bot.send_message(chat_id=admin,
-                                                    text=f"Сообщения от пользователя: {message.from_user.full_name}\n"
-                                                         f"Текст сообщения: {message.text}\n"
-                                                         f"Телефон: {tel}\n"
-                                                         f"Номер договору: {database.data[2]}\n",
-                                                    parse_mode='HTML',
-                                                    reply_markup=answer_reply)
-                    await db.message("BOT", 10001, msg.html_text, msg.date)
-                elif message.content_type == 'photo':
-                    msg = await dp.bot.send_photo(chat_id=admin,
-                                                  photo=message.photo[-1].file_id,
-                                                  caption=f"Сообщения от пользователя: {message.from_user.full_name}\n"
-                                                          f"Текст сообщения: {message.caption}\n"
-                                                          f"Телефон: {tel}\n"
-                                                          f"Номер договору: {database.data[2]}\n",
-                                                  parse_mode='HTML',
-                                                  reply_markup=answer_reply)
-                    await db.message("BOT", 10001, msg.html_text, msg.date)
-                elif message.content_type == 'document':
-                    msg = await dp.bot.send_document(chat_id=admin,
-                                                     document=message.document.file_id,
-                                                     caption=f"Сообщения от пользователя:"
-                                                             f" {message.from_user.full_name}\n"
-                                                             f"Телефон: {tel}\n"
-                                                             f"Номер договору: {database.data[2]}\n",
-                                                     parse_mode='HTML',
-                                                     reply_markup=answer_reply)
-                    await db.message("BOT", 10001, msg.html_text, msg.date)
-                elif message.content_type == 'video':
-                    msg = await dp.bot.send_video(chat_id=admin,
-                                                  video=message.video.file_id,
-                                                  caption=f"Сообщения от пользователя:"
-                                                          f" {message.from_user.full_name}\n"
-                                                          f"Телефон: {tel}\n"
-                                                          f"Номер договору: {database.data[2]}\n",
-                                                  parse_mode='HTML',
-                                                  reply_markup=answer_reply)
-                    await db.message("BOT", 10001, msg.html_text, msg.date)
+            answer_reply = InlineKeyboardMarkup()
+            answer_reply.add(InlineKeyboardButton(text="Відповісти",
+                                                  callback_data=f"answer {message.from_user.id}"))
+            if message.content_type == 'text':
+                notify_text = (f"Сообщения от пользователя: {message.from_user.full_name}\n"
+                               f"Текст сообщения: {message.text}\n"
+                               f"Телефон: {tel}\n"
+                               f"Номер договору: {database.data[2]}\n")
+                await asyncio.gather(
+                    *[dp.bot.send_message(chat_id=admin, text=notify_text,
+                                          parse_mode='HTML', reply_markup=answer_reply)
+                      for admin in ADMINS],
+                    return_exceptions=True
+                )
+            elif message.content_type == 'photo':
+                notify_caption = (f"Сообщения от пользователя: {message.from_user.full_name}\n"
+                                  f"Текст сообщения: {message.caption}\n"
+                                  f"Телефон: {tel}\n"
+                                  f"Номер договору: {database.data[2]}\n")
+                await asyncio.gather(
+                    *[dp.bot.send_photo(chat_id=admin, photo=message.photo[-1].file_id,
+                                        caption=notify_caption, parse_mode='HTML',
+                                        reply_markup=answer_reply)
+                      for admin in ADMINS],
+                    return_exceptions=True
+                )
+            elif message.content_type == 'document':
+                notify_caption = (f"Сообщения от пользователя:"
+                                  f" {message.from_user.full_name}\n"
+                                  f"Телефон: {tel}\n"
+                                  f"Номер договору: {database.data[2]}\n")
+                await asyncio.gather(
+                    *[dp.bot.send_document(chat_id=admin, document=message.document.file_id,
+                                           caption=notify_caption, parse_mode='HTML',
+                                           reply_markup=answer_reply)
+                      for admin in ADMINS],
+                    return_exceptions=True
+                )
+            elif message.content_type == 'video':
+                notify_caption = (f"Сообщения от пользователя:"
+                                  f" {message.from_user.full_name}\n"
+                                  f"Телефон: {tel}\n"
+                                  f"Номер договору: {database.data[2]}\n")
+                await asyncio.gather(
+                    *[dp.bot.send_video(chat_id=admin, video=message.video.file_id,
+                                        caption=notify_caption, parse_mode='HTML',
+                                        reply_markup=answer_reply)
+                      for admin in ADMINS],
+                    return_exceptions=True
+                )
         except Exception as err:
             logging.exception(err)
     else:
@@ -126,44 +134,50 @@ async def bot_echo(message: types.Message):
                 reply_markup=unknown_request_button)
             await db.message("BOT", 10001, msg.html_text, msg.date)
         try:
-            for admin in ADMINS:
-                answer_reply = InlineKeyboardMarkup()
-                answer_reply.add(InlineKeyboardButton(text="Відповісти",
-                                                      callback_data=f"answer {message.from_user.id}"))
-                if message.content_type == 'text':
-                    msg = await dp.bot.send_message(chat_id=admin,
-                                                    text=f"Сообщения от пользователя: {message.from_user.full_name}\n"
-                                                         f"Текст сообщения: {message.text}\n"
-                                                         f"Пользователь без телефона",
-                                                    parse_mode='HTML',
-                                                    reply_markup=answer_reply)
-                    await db.message("BOT", 10001, msg.html_text, msg.date)
-                elif message.content_type == 'photo':
-                    msg = await dp.bot.send_photo(chat_id=admin,
-                                                  photo=message.photo[-1].file_id,
-                                                  caption=f"Сообщения от пользователя: {message.from_user.full_name}\n"
-                                                          f"Пользователь без телефона",
-                                                  parse_mode='HTML',
-                                                  reply_markup=answer_reply)
-                    await db.message("BOT", 10001, msg.html_text, msg.date)
-                elif message.content_type == 'document':
-                    msg = await dp.bot.send_document(chat_id=admin,
-                                                     document=message.document.file_id,
-                                                     caption=f"Сообщения от пользователя:"
-                                                             f" {message.from_user.full_name}\n"
-                                                             f"Пользователь без телефона",
-                                                     reply_markup=answer_reply)
-                    await db.message("BOT", 10001, msg.html_text, msg.date)
-                elif message.content_type == 'video':
-                    msg = await dp.bot.send_video(chat_id=admin,
-                                                  video=message.video.file_id,
-                                                  caption=f"Сообщения от пользователя:"
-                                                          f" {message.from_user.full_name}\n"
-
-                                                          f"Пользователь без телефона",
-                                                  parse_mode='HTML',
-                                                  reply_markup=answer_reply)
-                    await db.message("BOT", 10001, msg.html_text, msg.date)
+            answer_reply = InlineKeyboardMarkup()
+            answer_reply.add(InlineKeyboardButton(text="Відповісти",
+                                                  callback_data=f"answer {message.from_user.id}"))
+            if message.content_type == 'text':
+                notify_text = (f"Сообщения от пользователя: {message.from_user.full_name}\n"
+                               f"Текст сообщения: {message.text}\n"
+                               f"Пользователь без телефона")
+                await asyncio.gather(
+                    *[dp.bot.send_message(chat_id=admin, text=notify_text,
+                                          parse_mode='HTML', reply_markup=answer_reply)
+                      for admin in ADMINS],
+                    return_exceptions=True
+                )
+            elif message.content_type == 'photo':
+                notify_caption = (f"Сообщения от пользователя: {message.from_user.full_name}\n"
+                                  f"Пользователь без телефона")
+                await asyncio.gather(
+                    *[dp.bot.send_photo(chat_id=admin, photo=message.photo[-1].file_id,
+                                        caption=notify_caption, parse_mode='HTML',
+                                        reply_markup=answer_reply)
+                      for admin in ADMINS],
+                    return_exceptions=True
+                )
+            elif message.content_type == 'document':
+                notify_caption = (f"Сообщения от пользователя:"
+                                  f" {message.from_user.full_name}\n"
+                                  f"Пользователь без телефона")
+                await asyncio.gather(
+                    *[dp.bot.send_document(chat_id=admin, document=message.document.file_id,
+                                           caption=notify_caption, reply_markup=answer_reply)
+                      for admin in ADMINS],
+                    return_exceptions=True
+                )
+            elif message.content_type == 'video':
+                notify_caption = (f"Сообщения от пользователя:"
+                                  f" {message.from_user.full_name}\n"
+                                  f"Пользователь без телефона")
+                await asyncio.gather(
+                    *[dp.bot.send_video(chat_id=admin, video=message.video.file_id,
+                                        caption=notify_caption, parse_mode='HTML',
+                                        reply_markup=answer_reply)
+                      for admin in ADMINS],
+                    return_exceptions=True
+                )
         except Exception as err:
             logging.exception(err)
 

--- a/handlers/users/pay_bill.py
+++ b/handlers/users/pay_bill.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import random
 import re
@@ -140,12 +141,14 @@ async def get_invoice_contract(message: types.Message, state: FSMContext):
                 ],
                 start_parameter=random_id
             )
-            for admin in ADMINS:
-                await dp.bot.send_message(admin,
-                                          f"Створено інвойс для користувача {message.from_user.id}:\n"
-                                          f"Договір: {contract}\n"
-                                          f"Сума: {payload} грн\n"
-                                          f"ID інвойсу: {random_id}")
+            invoice_notify_text = (f"Створено інвойс для користувача {message.from_user.id}:\n"
+                                   f"Договір: {contract}\n"
+                                   f"Сума: {payload} грн\n"
+                                   f"ID інвойсу: {random_id}")
+            await asyncio.gather(
+                *[dp.bot.send_message(admin, invoice_notify_text) for admin in ADMINS],
+                return_exceptions=True
+            )
             try:
                 await bot.send_invoice(message.from_user.id, **invoice.generate_invoice(), payload=str(amount_pay))
                 await state.reset_state(with_data=False)
@@ -218,13 +221,11 @@ async def process_successful_pay(message: types.Message, state: FSMContext):
                               message.from_user.username, contract, payload)
             await database.pay_balance(contract=contract, payload=payload)
             logging.info(f"Manual payment OK: contract={contract}, payload={payload}, user={message.from_user.id}")
-            for admin in ADMINS:
-                try:
-                    await dp.bot.send_message(
-                        chat_id=admin,
-                        text=f"Користувач {contract} успішно поповнив рахунок на {payload} {message.successful_payment.currency}")
-                except Exception as err:
-                    logging.exception(err)
+            notify_text = f"Користувач {contract} успішно поповнив рахунок на {payload} {message.successful_payment.currency}"
+            await asyncio.gather(
+                *[dp.bot.send_message(chat_id=admin, text=notify_text) for admin in ADMINS],
+                return_exceptions=True
+            )
             msg = await dp.bot.send_message(
                 chat_id=message.from_user.id,
                 text=__("Ваш рахунок поповнено на {} {}!").format(payload, message.successful_payment.currency),
@@ -255,13 +256,11 @@ async def process_successful_pay(message: types.Message, state: FSMContext):
                                   message.from_user.username, contract_str, str(payload))
             await database.pay_balance(contract=contract_str, payload=payload)
             logging.info(f"Auto-tariff payment OK: contract={contract_str}, payload={payload}, user={message.from_user.id}")
-            for admin in ADMINS:
-                try:
-                    await dp.bot.send_message(
-                        chat_id=admin,
-                        text=f"Користувач {contract_str} успішно поповнив рахунок на {payload} {message.successful_payment.currency}")
-                except Exception as err:
-                    logging.exception(err)
+            notify_text = f"Користувач {contract_str} успішно поповнив рахунок на {payload} {message.successful_payment.currency}"
+            await asyncio.gather(
+                *[dp.bot.send_message(chat_id=admin, text=notify_text) for admin in ADMINS],
+                return_exceptions=True
+            )
             msg = await dp.bot.send_message(
                 chat_id=message.from_user.id,
                 text=__("Ваш рахунок поповнено на {} {}!").format(payload, message.successful_payment.currency),
@@ -275,11 +274,9 @@ async def process_successful_pay(message: types.Message, state: FSMContext):
             text=__("На жаль, виникла помилка при обробці платежу. Будь ласка, зверніться до служби підтримки."),
             reply_markup=return_button)
         await db.message("BOT", 10001, error_msg.html_text, error_msg.date)
-        for admin in ADMINS:
-            try:
-                await dp.bot.send_message(
-                    chat_id=admin,
-                    text=f"Помилка платежу user={message.from_user.id}: {e}")
-            except Exception:
-                pass
+        error_notify_text = f"Помилка платежу user={message.from_user.id}: {e}"
+        await asyncio.gather(
+            *[dp.bot.send_message(chat_id=admin, text=error_notify_text) for admin in ADMINS],
+            return_exceptions=True
+        )
         await state.finish()

--- a/handlers/users/pay_bill.py
+++ b/handlers/users/pay_bill.py
@@ -4,6 +4,8 @@ import random
 import re
 import uuid
 
+logger = logging.getLogger(__name__)
+
 import aiogram.utils.exceptions
 from aiogram import types
 from aiogram.dispatcher import FSMContext
@@ -145,10 +147,13 @@ async def get_invoice_contract(message: types.Message, state: FSMContext):
                                    f"Договір: {contract}\n"
                                    f"Сума: {payload} грн\n"
                                    f"ID інвойсу: {random_id}")
-            await asyncio.gather(
+            results = await asyncio.gather(
                 *[dp.bot.send_message(admin, invoice_notify_text) for admin in ADMINS],
                 return_exceptions=True
             )
+            for r in results:
+                if isinstance(r, Exception):
+                    logger.error("Failed to notify admin about invoice: %s", r)
             try:
                 await bot.send_invoice(message.from_user.id, **invoice.generate_invoice(), payload=str(amount_pay))
                 await state.reset_state(with_data=False)
@@ -222,10 +227,13 @@ async def process_successful_pay(message: types.Message, state: FSMContext):
             await database.pay_balance(contract=contract, payload=payload)
             logging.info(f"Manual payment OK: contract={contract}, payload={payload}, user={message.from_user.id}")
             notify_text = f"Користувач {contract} успішно поповнив рахунок на {payload} {message.successful_payment.currency}"
-            await asyncio.gather(
+            results = await asyncio.gather(
                 *[dp.bot.send_message(chat_id=admin, text=notify_text) for admin in ADMINS],
                 return_exceptions=True
             )
+            for r in results:
+                if isinstance(r, Exception):
+                    logger.error("Failed to notify admin about payment: %s", r)
             msg = await dp.bot.send_message(
                 chat_id=message.from_user.id,
                 text=__("Ваш рахунок поповнено на {} {}!").format(payload, message.successful_payment.currency),
@@ -257,10 +265,13 @@ async def process_successful_pay(message: types.Message, state: FSMContext):
             await database.pay_balance(contract=contract_str, payload=payload)
             logging.info(f"Auto-tariff payment OK: contract={contract_str}, payload={payload}, user={message.from_user.id}")
             notify_text = f"Користувач {contract_str} успішно поповнив рахунок на {payload} {message.successful_payment.currency}"
-            await asyncio.gather(
+            results = await asyncio.gather(
                 *[dp.bot.send_message(chat_id=admin, text=notify_text) for admin in ADMINS],
                 return_exceptions=True
             )
+            for r in results:
+                if isinstance(r, Exception):
+                    logger.error("Failed to notify admin about payment: %s", r)
             msg = await dp.bot.send_message(
                 chat_id=message.from_user.id,
                 text=__("Ваш рахунок поповнено на {} {}!").format(payload, message.successful_payment.currency),
@@ -268,15 +279,18 @@ async def process_successful_pay(message: types.Message, state: FSMContext):
             await db.message("BOT", 10001, msg.html_text, msg.date)
             await state.finish()
     except Exception as e:
-        logging.error(f"Payment processing error for user {message.from_user.id}: {e}", exc_info=True)
+        logger.error("Payment processing error for user %s: %s", message.from_user.id, e, exc_info=True)
         error_msg = await dp.bot.send_message(
             chat_id=message.from_user.id,
             text=__("На жаль, виникла помилка при обробці платежу. Будь ласка, зверніться до служби підтримки."),
             reply_markup=return_button)
         await db.message("BOT", 10001, error_msg.html_text, error_msg.date)
         error_notify_text = f"Помилка платежу user={message.from_user.id}: {e}"
-        await asyncio.gather(
+        results = await asyncio.gather(
             *[dp.bot.send_message(chat_id=admin, text=error_notify_text) for admin in ADMINS],
             return_exceptions=True
         )
+        for r in results:
+            if isinstance(r, Exception):
+                logger.error("Failed to notify admin about payment error: %s", r)
         await state.finish()

--- a/handlers/users/start.py
+++ b/handlers/users/start.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 
 import asyncpg
@@ -84,14 +85,21 @@ async def ua_tel_get(message: types.Message, state: FSMContext):
     tel = format_number(tel)
     await db.update_phone_number(tel, message.from_user.id)
     await database.search_query(tel)
-    for admin in ADMINS:
-        await dp.bot.send_message(admin, text=f"Новий клієнт: {message.from_user.full_name}, {message.from_user.id}\n"
-                                              f"З номером телефону: {tel}\n")
-        if len(database.data) > 0:
-            await dp.bot.send_message(admin, text=f"Клієнт знайдений в білінгу, його номер договору "
-                                                  f"{database.data[2]}\n")
-        else:
-            await dp.bot.send_message(admin, text=f"Клієнт не знайдений в білінгу\n")
+    new_client_text = (f"Новий клієнт: {message.from_user.full_name}, {message.from_user.id}\n"
+                       f"З номером телефону: {tel}\n")
+    await asyncio.gather(
+        *[dp.bot.send_message(admin, text=new_client_text) for admin in ADMINS],
+        return_exceptions=True
+    )
+    if len(database.data) > 0:
+        billing_text = (f"Клієнт знайдений в білінгу, його номер договору "
+                        f"{database.data[2]}\n")
+    else:
+        billing_text = f"Клієнт не знайдений в білінгу\n"
+    await asyncio.gather(
+        *[dp.bot.send_message(admin, text=billing_text) for admin in ADMINS],
+        return_exceptions=True
+    )
     try:
         await db.set_contract(database.data[2], message.from_user.id)
     except IndexError:
@@ -312,22 +320,23 @@ async def tech_support_message(message: types.Message, state: FSMContext):
     user = await db.select_user_by_id(message.from_user.id)
     async with state.proxy() as data:
         data["Заявка"] = answer
-        for admin in ADMINS:
-            try:
-                answer_reply = InlineKeyboardMarkup()
-                answer_reply.add(InlineKeyboardButton(text="Відповісти",
-                                                      callback_data=f"answer {message.from_user.id}"))
-                msg = await dp.bot.send_message(admin, f"Завка на виклик майстра: {data['Заявка']}")
-                msg1 = await dp.bot.send_message(admin, f"Користувач: {user[1]}"
-                                                        f"\nНомер телефону: {user[5]}"
-                                                        f"\nНомер договору: {user[6]}"
-                                                        f"\nТелеграм ІД: {user[3]}",
-                                                 reply_markup=answer_reply)
-                await db.message("BOT", 10001, msg1.html_text, msg1.date)
-                await db.message("BOT", 10001, msg.html_text, msg.date)
+        answer_reply = InlineKeyboardMarkup()
+        answer_reply.add(InlineKeyboardButton(text="Відповісти",
+                                              callback_data=f"answer {message.from_user.id}"))
+        request_text = f"Завка на виклик майстра: {data['Заявка']}"
+        user_info_text = (f"Користувач: {user[1]}"
+                          f"\nНомер телефону: {user[5]}"
+                          f"\nНомер договору: {user[6]}"
+                          f"\nТелеграм ІД: {user[3]}")
 
-            except Exception as err:
-                logging.exception(err)
+        async def _notify_admin_tech(admin_id):
+            await dp.bot.send_message(admin_id, request_text)
+            await dp.bot.send_message(admin_id, user_info_text, reply_markup=answer_reply)
+
+        await asyncio.gather(
+            *[_notify_admin_tech(admin) for admin in ADMINS],
+            return_exceptions=True
+        )
     await state.reset_state()
     msg = await message.answer(text=_("Заявка в опрацюванні, чекайте зв'язку\n"
                                       "Можете повернутись у головне меню скориставшись кнопкою знизу"),
@@ -373,22 +382,23 @@ async def request_client(message: types.Message, state: FSMContext):
     user = await db.select_user_by_id(message.from_user.id)
     async with state.proxy() as data:
         data["Заявка"] = answer
-        for admin in ADMINS:
-            try:
-                answer_reply = InlineKeyboardMarkup()
-                answer_reply.add(InlineKeyboardButton(text="Відповісти",
-                                                      callback_data=f"answer {message.from_user.id}"))
-                msg = await dp.bot.send_message(admin, f"Заявка на подключение: {data['Заявка']}")
-                msg1 = await dp.bot.send_message(admin, f"Користувач: {user[1]}"
-                                                        f"\nНомер телефону: {user[5]}"
-                                                        f"\nНомер договору: {user[6]}"
-                                                        f"\nТелеграм ІД: {user[3]}",
-                                                 reply_markup=answer_reply)
-                await db.message("BOT", 10001, msg1.html_text, msg1.date)
-                await db.message("BOT", 10001, msg.html_text, msg.date)
+        answer_reply = InlineKeyboardMarkup()
+        answer_reply.add(InlineKeyboardButton(text="Відповісти",
+                                              callback_data=f"answer {message.from_user.id}"))
+        connect_text = f"Заявка на подключение: {data['Заявка']}"
+        user_info_text = (f"Користувач: {user[1]}"
+                          f"\nНомер телефону: {user[5]}"
+                          f"\nНомер договору: {user[6]}"
+                          f"\nТелеграм ІД: {user[3]}")
 
-            except Exception as err:
-                logging.exception(err)
+        async def _notify_admin_connect(admin_id):
+            await dp.bot.send_message(admin_id, connect_text)
+            await dp.bot.send_message(admin_id, user_info_text, reply_markup=answer_reply)
+
+        await asyncio.gather(
+            *[_notify_admin_connect(admin) for admin in ADMINS],
+            return_exceptions=True
+        )
     await state.reset_state()
     msg = await message.answer(text=_("Заявка в опрацюванні, чекайте зв'язку\n"
                                       "Можете повернутись у головне меню скориставшись кнопкою знизу"),

--- a/handlers/users/start.py
+++ b/handlers/users/start.py
@@ -1,6 +1,8 @@
 import asyncio
 import logging
 
+logger = logging.getLogger(__name__)
+
 import asyncpg
 from aiogram import types
 from aiogram.dispatcher import FSMContext
@@ -87,19 +89,25 @@ async def ua_tel_get(message: types.Message, state: FSMContext):
     await database.search_query(tel)
     new_client_text = (f"Новий клієнт: {message.from_user.full_name}, {message.from_user.id}\n"
                        f"З номером телефону: {tel}\n")
-    await asyncio.gather(
+    results = await asyncio.gather(
         *[dp.bot.send_message(admin, text=new_client_text) for admin in ADMINS],
         return_exceptions=True
     )
+    for r in results:
+        if isinstance(r, Exception):
+            logger.error("Failed to notify admin: %s", r)
     if len(database.data) > 0:
         billing_text = (f"Клієнт знайдений в білінгу, його номер договору "
                         f"{database.data[2]}\n")
     else:
         billing_text = f"Клієнт не знайдений в білінгу\n"
-    await asyncio.gather(
+    results = await asyncio.gather(
         *[dp.bot.send_message(admin, text=billing_text) for admin in ADMINS],
         return_exceptions=True
     )
+    for r in results:
+        if isinstance(r, Exception):
+            logger.error("Failed to notify admin: %s", r)
     try:
         await db.set_contract(database.data[2], message.from_user.id)
     except IndexError:
@@ -333,10 +341,13 @@ async def tech_support_message(message: types.Message, state: FSMContext):
             await dp.bot.send_message(admin_id, request_text)
             await dp.bot.send_message(admin_id, user_info_text, reply_markup=answer_reply)
 
-        await asyncio.gather(
+        results = await asyncio.gather(
             *[_notify_admin_tech(admin) for admin in ADMINS],
             return_exceptions=True
         )
+        for r in results:
+            if isinstance(r, Exception):
+                logger.error("Failed to notify admin: %s", r)
     await state.reset_state()
     msg = await message.answer(text=_("Заявка в опрацюванні, чекайте зв'язку\n"
                                       "Можете повернутись у головне меню скориставшись кнопкою знизу"),
@@ -395,10 +406,13 @@ async def request_client(message: types.Message, state: FSMContext):
             await dp.bot.send_message(admin_id, connect_text)
             await dp.bot.send_message(admin_id, user_info_text, reply_markup=answer_reply)
 
-        await asyncio.gather(
+        results = await asyncio.gather(
             *[_notify_admin_connect(admin) for admin in ADMINS],
             return_exceptions=True
         )
+        for r in results:
+            if isinstance(r, Exception):
+                logger.error("Failed to notify admin: %s", r)
     await state.reset_state()
     msg = await message.answer(text=_("Заявка в опрацюванні, чекайте зв'язку\n"
                                       "Можете повернутись у головне меню скориставшись кнопкою знизу"),

--- a/handlers/users/time_pay.py
+++ b/handlers/users/time_pay.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from aiogram import types
 from aiogram.dispatcher.filters import Text
 
@@ -22,8 +24,11 @@ async def time_pay(message: types.Message):
     "Рахунок поповнено на {} грн на 24 години! Тепер можете повернутись у головне меню").format(database.time_pay_b[0]),
                                    reply_markup=return_button)
         await db.message("BOT", 10001, msg.html_text, msg.date)
-        for admin in ADMINS:
-            await dp.bot.send_message(admin, _("Користувач {} використав тимчасовий платіж!").format(user))
+        notify_text = _("Користувач {} використав тимчасовий платіж!").format(user)
+        await asyncio.gather(
+            *[dp.bot.send_message(admin, notify_text) for admin in ADMINS],
+            return_exceptions=True
+        )
     else:
         msg = await message.answer(text=_("Ви не можете використати тимчасовий платіж!\n"
                                           "Користуватись тимчасовим платежем можна раз на місяць!"),

--- a/handlers/users/time_pay.py
+++ b/handlers/users/time_pay.py
@@ -1,4 +1,7 @@
 import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
 
 from aiogram import types
 from aiogram.dispatcher.filters import Text
@@ -25,10 +28,13 @@ async def time_pay(message: types.Message):
                                    reply_markup=return_button)
         await db.message("BOT", 10001, msg.html_text, msg.date)
         notify_text = _("Користувач {} використав тимчасовий платіж!").format(user)
-        await asyncio.gather(
+        results = await asyncio.gather(
             *[dp.bot.send_message(admin, notify_text) for admin in ADMINS],
             return_exceptions=True
         )
+        for r in results:
+            if isinstance(r, Exception):
+                logger.error("Failed to notify admin about time pay: %s", r)
     else:
         msg = await message.answer(text=_("Ви не можете використати тимчасовий платіж!\n"
                                           "Користуватись тимчасовим платежем можна раз на місяць!"),

--- a/utils/misc/find_in_bill.py
+++ b/utils/misc/find_in_bill.py
@@ -1,21 +1,29 @@
 import aiomysql
 import asyncio
+import logging
 import time
 
 from data import config
 
 loop = asyncio.get_event_loop()
 
+_streets_cache = None
+
 
 async def find(contract=None, phone=None, name=None, address: list = None):
+    global _streets_cache
     conn = await aiomysql.connect(host=config.BILL_HOST, port=int(config.BILL_PORT),
                                   user=config.BILL_USER, password=config.BILL_PASS,
                                   db=config.BILL_NAME, loop=loop, charset="cp1251")
     cur = await conn.cursor()
-    await cur.execute("SELECT name_street FROM `p_street`")
-    streets = await cur.fetchall()
-    streets = [street[0] for street in streets]
-    print(streets)
+    if _streets_cache is None:
+        await cur.execute("SELECT name_street FROM `p_street`")
+        streets = await cur.fetchall()
+        streets = [street[0] for street in streets]
+        _streets_cache = streets
+    else:
+        streets = _streets_cache
+    logging.debug("Streets: %s", streets)
     try:
         if address:
             if address[0] in streets:
@@ -46,7 +54,7 @@ async def find(contract=None, phone=None, name=None, address: list = None):
                     raise ValueError("Too many arguments")
 
     except TypeError as e:
-        print(e)
+        logging.debug("TypeError in find(): %s", e)
     if contract:
         await cur.execute("SELECT name, balance, contract, fio, state, paket, telefon, street, house, room, ip, id "
                           "FROM `users` "
@@ -59,10 +67,10 @@ async def find(contract=None, phone=None, name=None, address: list = None):
         sql = "SELECT name, balance, contract, fio, state, paket, telefon, street, house, room, ip, id " \
               "FROM `users` " \
               f"WHERE fio LIKE '%{name}%' "
-        print(sql)
+        logging.debug("SQL query: %s", sql)
         await cur.execute(sql.encode('cp1251'))
     result = await cur.fetchall()
-    print(result)
+    logging.debug("Query result: %s", result)
 
     if len(result) == 1:
         result = result[0]


### PR DESCRIPTION
## Summary
- **Unit 10**: Cache streets table in find_in_bill (from PR #9)
- **Unit 9**: Parallelize admin notifications with asyncio.gather (from PR #6)
- **Bug 2 fix**: Restore db.message() logging dropped by gather() refactoring in echo.py. Add error logging for failed admin sends across all gather() sites (echo.py, start.py, pay_bill.py, time_pay.py)