### PR TITLE
perf: replace print() with proper logging

### DIFF
--- a/handlers/errors/error_handler.py
+++ b/handlers/errors/error_handler.py
@@ -4,6 +4,7 @@ from aiogram.utils.exceptions import (Unauthorized, InvalidQueryID, TelegramAPIE
                                       MessageTextIsEmpty, RetryAfter,
                                       CantParseEntities, MessageCantBeDeleted)
 
+logger = logging.getLogger(__name__)
 
 from loader import dp
 
@@ -19,40 +20,40 @@ async def errors_handler(update, exception):
     """
 
     if isinstance(exception, CantDemoteChatCreator):
-        logging.debug("Can't demote chat creator")
+        logger.debug("Can't demote chat creator")
         return True
 
     if isinstance(exception, MessageNotModified):
-        logging.debug('Message is not modified')
+        logger.debug('Message is not modified')
         return True
     if isinstance(exception, MessageCantBeDeleted):
-        logging.debug('Message cant be deleted')
+        logger.debug('Message cant be deleted')
         return True
 
     if isinstance(exception, MessageToDeleteNotFound):
-        logging.debug('Message to delete not found')
+        logger.debug('Message to delete not found')
         return True
 
     if isinstance(exception, MessageTextIsEmpty):
-        logging.debug('MessageTextIsEmpty')
+        logger.debug('MessageTextIsEmpty')
         return True
 
     if isinstance(exception, Unauthorized):
-        logging.info(f'Unauthorized: {exception}')
+        logger.info("Unauthorized: %s", exception)
         return True
 
     if isinstance(exception, InvalidQueryID):
-        logging.exception(f'InvalidQueryID: {exception} \nUpdate: {update}')
+        logger.exception("InvalidQueryID: %s \nUpdate: %s", exception, update)
         return True
 
     if isinstance(exception, TelegramAPIError):
-        logging.exception(f'TelegramAPIError: {exception} \nUpdate: {update}')
+        logger.exception("TelegramAPIError: %s \nUpdate: %s", exception, update)
         return True
     if isinstance(exception, RetryAfter):
-        logging.exception(f'RetryAfter: {exception} \nUpdate: {update}')
+        logger.exception("RetryAfter: %s \nUpdate: %s", exception, update)
         return True
     if isinstance(exception, CantParseEntities):
-        logging.exception(f'CantParseEntities: {exception} \nUpdate: {update}')
+        logger.exception("CantParseEntities: %s \nUpdate: %s", exception, update)
         return True
     
-    logging.exception(f'Update: {update} \n{exception}')
+    logger.exception("Update: %s \n%s", update, exception)

--- a/handlers/users/echo.py
+++ b/handlers/users/echo.py
@@ -31,7 +31,7 @@ async def bot_echo(message: types.Message):
     tel = await db.select_tel(message.from_user.id)
     ban = await db.get_ban()
 
-    print(ban)
+    logger.debug("Ban list: %s", ban)
     if await db.is_alarm(message.from_user.id):
         await database.search_query(tel)
         if len(database.data) > 0:

--- a/handlers/users/panel.py
+++ b/handlers/users/panel.py
@@ -1,8 +1,11 @@
 import asyncio
+import logging
 import re
 
 import aiohttp
 import transliterate
+
+logger = logging.getLogger(__name__)
 from aiogram import types
 from aiogram.dispatcher import FSMContext
 from aiogram.dispatcher.filters import IDFilter, Text
@@ -113,7 +116,7 @@ async def toggle_payment_stub(call: types.CallbackQuery):
 async def admin_answer(call: types.CallbackQuery, state: FSMContext):
     await state.finish()
     user_id = call.data.split(" ")[1]
-    print(user_id)
+    logger.debug("Admin answering user_id: %s", user_id)
     await state.set_state("answer")
     await state.set_data({"user_id": user_id})
     await db.message(
@@ -153,7 +156,7 @@ async def message_history_start(call: types.CallbackQuery, state: FSMContext):
 )
 async def admin_answer_text(message: types.Message, state: FSMContext):
     user_id = await state.get_data()
-    print(user_id)
+    logger.debug("Admin answer text user_id: %s", user_id)
     await state.finish()
     if message.content_type == "text":
         await dp.bot.send_message(user_id["user_id"], message.text)
@@ -344,7 +347,7 @@ async def account_menu_handler(message: types.Message, state: FSMContext):
                 text=f"Не вдалося знайти користувача", reply_markup=back
             )
     except Exception as e:
-        print(e)
+        logger.exception("Error searching for user: %s", e)
         await message.answer(
             text=f"Не вдалося знайти користувача з номером договору {message.text}",
             reply_markup=back,
@@ -383,7 +386,7 @@ async def message_history_get(message: types.Message, state: FSMContext):
     msg = await message.answer(
         f"Останні {message.text} повідомлень від {contract['account']}"
     )
-    print(messages)
+    logger.debug("Message history: %s", messages)
     for i in messages:
         if i[0] is not None:
             msg1 = await message.answer(i[0])
@@ -447,7 +450,7 @@ async def admin_change_balance_handler(message: types.Message, state: FSMContext
     )
     account = await state.get_data()
     account = account["account"]
-    print(account)
+    logger.debug("Admin change balance for account: %s", account)
     try:
         await pay_balance(account, message.text)
         msg = await message.answer(
@@ -459,8 +462,7 @@ async def admin_change_balance_handler(message: types.Message, state: FSMContext
         phone = result["telefon"]
         if len(phone) > 13:
             phone = phone[:13]
-            print(phone)
-        print(phone)
+        logger.debug("Phone for SMS notification: %s", phone)
         try:
             text = (
                 "Рахунок "
@@ -472,10 +474,10 @@ async def admin_change_balance_handler(message: types.Message, state: FSMContext
             )
             await send_message_sms(unformat_number(phone), text)
         except Exception as e:
-            print(e)
+            logger.exception("Error sending SMS notification: %s", e)
         await state.finish()
     except Exception as e:
-        print(e)
+        logger.exception("Error changing balance: %s", e)
         msg = await message.answer(
             text=f"Не вдалося поповнити баланс користувача {account} на {message.text}",
             reply_markup=back,
@@ -542,7 +544,7 @@ async def message_get_phone(message: types.Message, state: FSMContext):
                 msg.date,
             )
     except Exception as e:
-        print(e)
+        logger.exception("Error finding phone/ID in bot: %s", e)
         msg = await message.answer(
             f"Телефон або ІД не знайдений у боті\nВиникла помилка при пошуку {e}"
         )
@@ -581,7 +583,7 @@ async def message_get_text(message: types.Message, state: FSMContext):
         await state.update_data(type="video")
         await state.update_data(video=message.video.file_id)
     data = await state.get_data()
-    print(data["phone"])
+    logger.debug("Sending message to phone: %s", data["phone"])
     users = await db.select_all_users()
     users_phones = []
     users_id = []
@@ -622,10 +624,10 @@ async def message_get_text(message: types.Message, state: FSMContext):
                 msg.date,
             )
     except Exception as e:
-        print(e)
+        logger.debug("Retrying with unformatted phone: %s", e)
         await state.update_data(phone=unformat_number(data["phone"]))
         data = await state.get_data()
-        print(data["phone"])
+        logger.debug("Unformatted phone: %s", data["phone"])
         for i in range(len(users)):
             users_phones.append(unformat_number(str(users[i]["phone_number"])))
             users_id.append(users[i]["telegram_id"])
@@ -684,7 +686,7 @@ async def message_send_accept(call: types.CallbackQuery, state: FSMContext):
     telegram_id = data["phone"]
     contract = await db.select_contract(int(telegram_id))
     contract = contract[0]["contract"]
-    print(telegram_id)
+    logger.debug("Sending message to telegram_id: %s", telegram_id)
     await call.answer()
     type = data["type"]
     if type == "text":
@@ -1037,21 +1039,14 @@ async def message_send_accept_sms(call: types.CallbackQuery, state: FSMContext):
                 )
                 await db.message("BOT", 10001, msg.html_text, msg.date)
                 if len(text) >= 53:
-                    print("transliterate")
+                    logger.debug("Applying transliteration")
                     email_text_t = transliterate.translit(text, "uk", reversed=True)
                     text = f"{email_text_t}\nt.me/infoaura_bot"
                 else:
-                    print("no transliterate")
+                    logger.debug("No transliteration needed")
                     text = f"{text}\nt.me/infoaura_bot"
                 async with aiohttp.ClientSession() as session:
-                    print(
-                        "Sending sms to:",
-                        phone,
-                        "with text:",
-                        text,
-                        "length of string:",
-                        len(text),
-                    )
+                    logger.info("Sending SMS to: %s, length: %s", phone, len(text))
                     param = {
                         "version": "http",
                         "login": "380936425274",
@@ -1065,7 +1060,7 @@ async def message_send_accept_sms(call: types.CallbackQuery, state: FSMContext):
                     async with session.request(
                         "http", "https://smsukraine.com.ua/api/http.php", params=param
                     ) as sms:
-                        print("SMS: ", await sms.text())
+                        logger.info("SMS response: %s", await sms.text())
                 for admin in ADMINS:
                     msg_1 = await dp.bot.send_message(
                         admin,
@@ -1197,7 +1192,7 @@ async def message_alarm_by_contract(message: types.Message, state: FSMContext):
     try:
         alarm_message = "За Вашим підключенням зареєстрована аварійна ситуація. Перевірте термін усунення аварії пізніше."
         await db.insert_alarm(alarm_message, message.text)
-        print(message.text)
+        logger.debug("Alarm contracts: %s", message.text)
         users = message.text.split(",")
         users_count = 0
         for user in users:
@@ -1205,7 +1200,7 @@ async def message_alarm_by_contract(message: types.Message, state: FSMContext):
                 if await db.set_alarm_for_users(user):
                     users_count += 1
             except Exception as e:
-                print(e)
+                logger.exception("Error setting alarm for user: %s", e)
         await message.answer(
             f"Зареєстровано аварію для {users_count} користувачів", reply_markup=back
         )
@@ -1226,7 +1221,7 @@ async def message_alarm_grp(call: types.CallbackQuery, state: FSMContext):
     try:
         alarm_message = "За Вашим підключенням зареєстрована аварійна ситуація. Перевірте термін усунення аварії пізніше."
         await db.insert_alarm(alarm_message, call.data)
-        print(call.data)
+        logger.debug("Alarm group: %s", call.data)
         users = await users_with_alarm(int(call.data))
         users_count = 0
         for user in users:
@@ -1234,7 +1229,7 @@ async def message_alarm_grp(call: types.CallbackQuery, state: FSMContext):
                 if await db.set_alarm_for_users(user):
                     users_count += 1
             except Exception as e:
-                print(e)
+                logger.exception("Error setting alarm for user: %s", e)
                 pass
         await call.message.edit_text(
             f"Аварію успішно зареєстровано для {users_count} абонентів",
@@ -1271,7 +1266,7 @@ async def redacting_alarm_state(call: types.CallbackQuery, state: FSMContext):
     records = await db.get_alarm()
     keyboard_alarms = InlineKeyboardMarkup(row_width=1)
     txt = ""
-    print(records)
+    logger.debug("Alarm records: %s", records)
     if not records:
         await call.message.edit_text("Аварій не знайдено", reply_markup=back_inline)
         await state.finish()

--- a/handlers/users/pay_bill.py
+++ b/handlers/users/pay_bill.py
@@ -36,7 +36,7 @@ async def contract_pay(message: types.Message, state: FSMContext):
 
     await database.search_query(tel=await db.select_tel(user_id=message.from_user.id))
     ban = await db.get_ban()
-    print(ban)
+    logger.debug("Ban list: %s", ban)
 
     if message.from_user.id in ban:
         await message.answer(_("Вітаємо! Для звернення, будь-ласка, скористайтесь нашим email технічної підтримки "
@@ -91,7 +91,7 @@ async def contract_pay(message: types.Message, state: FSMContext):
             await state.set_state('invoice_payload')
             await db.message("BOT", 10001, msg.html_text, msg.date)
     except IndexError as e:
-        print(e)
+        logger.debug("IndexError in contract_pay: %s", e)
         msg = await message.answer(text=_("Для поповнення рахунку введіть сумму поповненя!\n"
                                           "Наприклад:\n"
                                           "250,\n"
@@ -100,7 +100,7 @@ async def contract_pay(message: types.Message, state: FSMContext):
         await state.set_state('invoice_payload')
         await db.message("BOT", 10001, msg.html_text, msg.date)
     except Exception as e:
-        print(e)
+        logger.exception("Error in contract_pay: %s", e)
         msg = await message.answer(text=_("Для поповнення рахунку введіть сумму поповненя!\n"
                                           "Наприклад:\n"
                                           "250,\n"
@@ -198,13 +198,12 @@ async def get_invoice_contract(message: types.Message, state: FSMContext):
 
 @dp.pre_checkout_query_handler(state='*')
 async def process_pre_checkout(query: types.PreCheckoutQuery):
-    print(f"[PRE_CHECKOUT] user={query.from_user.id}, payload={query.invoice_payload}")
-    logging.info(f"Pre-checkout: user={query.from_user.id}, amount={query.total_amount}, payload={query.invoice_payload}")
+    logger.info("Pre-checkout: user=%s, amount=%s, payload=%s", query.from_user.id, query.total_amount, query.invoice_payload)
     try:
         await bot.answer_pre_checkout_query(pre_checkout_query_id=query.id, ok=True)
-        print(f"[PRE_CHECKOUT] ok=True sent for user={query.from_user.id}")
+        logger.info("Pre-checkout ok=True sent for user=%s", query.from_user.id)
     except Exception as e:
-        logging.error(f"Pre-checkout error: user={query.from_user.id}: {e}", exc_info=True)
+        logger.error("Pre-checkout error: user=%s: %s", query.from_user.id, e, exc_info=True)
         await bot.answer_pre_checkout_query(
             pre_checkout_query_id=query.id, ok=False,
             error_message="Виникла помилка. Спробуйте ще раз."
@@ -213,7 +212,7 @@ async def process_pre_checkout(query: types.PreCheckoutQuery):
 
 @dp.message_handler(content_types=ContentType.SUCCESSFUL_PAYMENT, state="*")
 async def process_successful_pay(message: types.Message, state: FSMContext):
-    logging.info(f"SUCCESSFUL_PAYMENT received: user={message.from_user.id}, amount={message.successful_payment.total_amount}")
+    logger.info("SUCCESSFUL_PAYMENT received: user=%s, amount=%s", message.from_user.id, message.successful_payment.total_amount)
     data = await state.get_data()
     try:
         await db.message(message.from_user.full_name, message.from_user.id, message.text, message.date)
@@ -225,7 +224,7 @@ async def process_successful_pay(message: types.Message, state: FSMContext):
             await db.add_bill(bill_id, message.from_user.id, message.date,
                               message.from_user.username, contract, payload)
             await database.pay_balance(contract=contract, payload=payload)
-            logging.info(f"Manual payment OK: contract={contract}, payload={payload}, user={message.from_user.id}")
+            logger.info("Manual payment OK: contract=%s, payload=%s, user=%s", contract, payload, message.from_user.id)
             notify_text = f"Користувач {contract} успішно поповнив рахунок на {payload} {message.successful_payment.currency}"
             results = await asyncio.gather(
                 *[dp.bot.send_message(chat_id=admin, text=notify_text) for admin in ADMINS],
@@ -263,7 +262,7 @@ async def process_successful_pay(message: types.Message, state: FSMContext):
                 await db.add_bill(bill_id, message.from_user.id, message.date,
                                   message.from_user.username, contract_str, str(payload))
             await database.pay_balance(contract=contract_str, payload=payload)
-            logging.info(f"Auto-tariff payment OK: contract={contract_str}, payload={payload}, user={message.from_user.id}")
+            logger.info("Auto-tariff payment OK: contract=%s, payload=%s, user=%s", contract_str, payload, message.from_user.id)
             notify_text = f"Користувач {contract_str} успішно поповнив рахунок на {payload} {message.successful_payment.currency}"
             results = await asyncio.gather(
                 *[dp.bot.send_message(chat_id=admin, text=notify_text) for admin in ADMINS],

--- a/handlers/users/start.py
+++ b/handlers/users/start.py
@@ -114,7 +114,7 @@ async def ua_tel_get(message: types.Message, state: FSMContext):
         pass
     net_on = _("Увімкнено")
     net_off = _("Вимкнено")
-    print(database.data)
+    logger.debug("Database data: %s", database.data)
     if len(database.data) > 0:
 
         net_pause = await database.check_net_pause(database.data[2])

--- a/utils/db_api/database.py
+++ b/utils/db_api/database.py
@@ -118,7 +118,7 @@ async def pay_balance(contract, payload):
                 id = user[1]
             except IndexError:
                 user = None
-                logging.info("User not Found")
+                logger.info("User not Found")
                 return False
             if paket:
                 await cur.execute(f"SELECT price FROM plans2 WHERE id = {paket}")
@@ -127,7 +127,7 @@ async def pay_balance(contract, payload):
                 price = price[0]
             except IndexError:
                 price = None
-                logging.info("Price not find")
+                logger.info("Price not find")
                 return False
             await cur.execute(f"UPDATE users set balance = balance + {payload} WHERE contract={contract}")
             await cur.execute("INSERT INTO pays (mid,cash,time,admin,reason,coment) VALUES (%s, %s, %s, %s, %s, %s)",
@@ -170,7 +170,7 @@ async def t_pay(contract):
                 id = user[8]
             except IndexError:
                 user = None
-                logging.info("User not Found")
+                logger.info("User not Found")
                 return False
 
             if time_pay == 0:
@@ -182,7 +182,7 @@ async def t_pay(contract):
                     logger.debug("Tariff price: %s", price)
                 except IndexError:
                     price = None
-                    logging.info("Price not find")
+                    logger.info("Price not find")
                     return False
 
                 if old_balance > 0:

--- a/utils/misc/find_in_bill.py
+++ b/utils/misc/find_in_bill.py
@@ -3,6 +3,8 @@ import time
 
 from utils.db_api import database
 
+logger = logging.getLogger(__name__)
+
 _streets_cache = None
 
 
@@ -17,7 +19,7 @@ async def find(contract=None, phone=None, name=None, address: list = None):
                 _streets_cache = streets
             else:
                 streets = _streets_cache
-            logging.debug("Streets: %s", streets)
+            logger.debug("Streets: %s", streets)
             try:
                 if address:
                     if address[0] in streets:
@@ -48,7 +50,7 @@ async def find(contract=None, phone=None, name=None, address: list = None):
                             raise ValueError("Too many arguments")
 
             except TypeError as e:
-                logging.debug("TypeError in find(): %s", e)
+                logger.debug("TypeError in find(): %s", e)
             if contract:
                 await cur.execute("SELECT name, balance, contract, fio, state, paket, telefon, street, house, room, ip, id "
                                   "FROM `users` "
@@ -61,10 +63,10 @@ async def find(contract=None, phone=None, name=None, address: list = None):
                 sql = "SELECT name, balance, contract, fio, state, paket, telefon, street, house, room, ip, id " \
                       "FROM `users` " \
                       f"WHERE fio LIKE '%{name}%' "
-                logging.debug("SQL query: %s", sql)
+                logger.debug("SQL query: %s", sql)
                 await cur.execute(sql.encode('cp1251'))
             result = await cur.fetchall()
-            logging.debug("Query result: %s", result)
+            logger.debug("Query result: %s", result)
 
             if len(result) == 1:
                 result = result[0]

--- a/utils/misc/sms_message.py
+++ b/utils/misc/sms_message.py
@@ -1,12 +1,15 @@
 import asyncio
 import base64
 import datetime
+import logging
 import transliterate
 import os.path
 import json
 import pickle
 
 import aiohttp
+
+logger = logging.getLogger(__name__)
 from asyncio import sleep
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
@@ -62,10 +65,10 @@ def _get_unread_emails():
 
     messages = results.get('messages', [])
 
-    print("Total Messages Unseen:", len(messages) if messages else 0)
+    logger.info("Total Messages Unseen: %s", len(messages) if messages else 0)
 
     if not messages:
-        print("No unread messages found.")
+        logger.info("No unread messages found.")
         return []
 
     parsed_emails = []
@@ -98,10 +101,7 @@ def _get_unread_emails():
             if header['name'] == 'Date':
                 date = header['value']
 
-        print("\n===========================================")
-        print("Subject: ", subject)
-        print("From: ", sender)
-        print("Date: ", date)
+        logger.info("Subject: %s, From: %s, Date: %s", subject, sender, date)
 
         # Отримуємо текст повідомлення
         message_text = ""
@@ -119,8 +119,7 @@ def _get_unread_emails():
                         message_text = base64.urlsafe_b64decode(data).decode('utf-8')
                         break
 
-        print("Message: \n", message_text)
-        print("==========================================\n")
+        logger.debug("Message: %s", message_text)
 
         parsed_emails.append({'phone': subject, 'text': message_text})
 
@@ -154,46 +153,44 @@ async def send_message_sms(phone: int = None, text: str = None):
             if email_phone[i] in users_phones:
                 try:
                     divider = email_text[i].find('-----')
-                    print(number(email_phone[i]))
+                    logger.debug("Phone: %s", number(email_phone[i]))
                     telegram_id = await db.select_id_by_phone(phone_number=number(email_phone[i]))
                     telegram_id = telegram_id[0]['telegram_id']
-                    print(telegram_id)
+                    logger.debug("Telegram ID: %s", telegram_id)
                     if divider:
                         await dp.bot.send_message(telegram_id, email_text[i][divider + 5:])
                         await db.message("BOT", 10001, email_text[i][divider + 5:], datetime.datetime.now())
-                        print("Message sent via bot to:", telegram_id)
+                        logger.info("Message sent via bot to: %s", telegram_id)
                     else:
                         await dp.bot.send_message(telegram_id, email_text[i])
                         await db.message("BOT", 10001, email_text[i], datetime.datetime.now())
-                        print("Message sent via bot to:", telegram_id)
+                        logger.info("Message sent via bot to: %s", telegram_id)
                 except UserDeactivated as e:
                     # Код для відправки SMS залишається незмінним
-                    print("Message sent via sms to:", email_phone[i])
+                    logger.info("Sending SMS (UserDeactivated) to: %s", email_phone[i])
                     try:
                         divider = email_text[i].find('-----')
                         if divider:
                             message_sms_text = f"{email_text[i][:divider]}\nt.me/infoaura_bot"
                         else:
                             message_sms_text = f"{email_text[i]}\nt.me/infoaura_bot"
-                        print(len(message_sms_text), " length of  string")
+                        logger.debug("SMS text length: %s", len(message_sms_text))
                         if len(message_sms_text) >= 70:
-                            print('transliterate')
+                            logger.debug("Applying transliteration")
                             if divider:
                                 email_text_t = transliterate.translit(email_text[i][:divider], 'uk', reversed=True)
                             else:
                                 email_text_t = transliterate.translit(email_text[i], 'uk', reversed=True)
                             message_sms_text = f"{email_text_t}\nt.me/infoaura_bot"
                         else:
-                            print("no transliterate")
+                            logger.debug("No transliteration needed")
                             if divider:
                                 message_sms_text = f"{email_text[i][:divider]}\nt.me/infoaura_bot"
                             else:
                                 message_sms_text = f"{email_text[i]}\nt.me/infoaura_bot"
                         await sleep(60)
                         async with aiohttp.ClientSession() as session:
-                            print("Sending sms to:", email_phone[i],
-                                  "with text:", message_sms_text,
-                                  "length of string:", len(message_sms_text))
+                            logger.info("Sending SMS to: %s, length: %s", email_phone[i], len(message_sms_text))
                             param = {'version': 'http',
                                      'login': '380936425274',
                                      "pass": "wxgjtqyo",
@@ -204,37 +201,35 @@ async def send_message_sms(phone: int = None, text: str = None):
                                      'message': f'{message_sms_text}'}
                             async with session.request('http', "https://smsukraine.com.ua/api/http.php",
                                                        params=param) as sms:
-                                print("SMS: ", await sms.text())
+                                logger.info("SMS response: %s", await sms.text())
                     except Exception as e:
-                        print(e)
+                        logger.exception("SMS send error: %s", e)
                     continue
                 except BotBlocked:
-                    print("Message sent via sms to:", email_phone[i])
+                    logger.info("Sending SMS (BotBlocked) to: %s", email_phone[i])
                     try:
                         divider = email_text[i].find('-----')
                         if divider:
                             message_sms_text = f"{email_text[i][:divider]}\nt.me/infoaura_bot"
                         else:
                             message_sms_text = f"{email_text[i]}\nt.me/infoaura_bot"
-                        print(len(message_sms_text), " length of  string")
+                        logger.debug("SMS text length: %s", len(message_sms_text))
                         if len(message_sms_text) >= 70:
-                            print('transliterate')
+                            logger.debug("Applying transliteration")
                             if divider:
                                 email_text_t = transliterate.translit(email_text[i][:divider], 'uk', reversed=True)
                             else:
                                 email_text_t = transliterate.translit(email_text[i], 'uk', reversed=True)
                             message_sms_text = f"{email_text_t}\nt.me/infoaura_bot"
                         else:
-                            print("no transliterate")
+                            logger.debug("No transliteration needed")
                             if divider:
                                 message_sms_text = f"{email_text[i][:divider]}\nt.me/infoaura_bot"
                             else:
                                 message_sms_text = f"{email_text[i]}\nt.me/infoaura_bot"
                         await sleep(60)
                         async with aiohttp.ClientSession() as session:
-                            print("Sending sms to:", email_phone[i],
-                                  "with text:", message_sms_text,
-                                  "length of string:", len(message_sms_text))
+                            logger.info("Sending SMS to: %s, length: %s", email_phone[i], len(message_sms_text))
                             param = {'version': 'http',
                                      'login': '380936425274',
                                      "password": "wxgjtqyo",
@@ -244,37 +239,35 @@ async def send_message_sms(phone: int = None, text: str = None):
                                      'message': f'{message_sms_text}'}
                             async with session.request('http', "https://smsukraine.com.ua/api/http.php",
                                                        params=param) as sms:
-                                print("SMS: ", await sms.text())
+                                logger.info("SMS response: %s", await sms.text())
                     except Exception as e:
-                        print(e)
+                        logger.exception("SMS send error: %s", e)
                     continue
             else:
-                print("Message sent via sms to:", email_phone[i])
+                logger.info("Sending SMS (not in bot users) to: %s", email_phone[i])
                 try:
                     divider = email_text[i].find('-----')
                     if divider:
                         message_sms_text = f"{email_text[i][:divider]}\nt.me/infoaura_bot"
                     else:
                         message_sms_text = f"{email_text[i]}\nt.me/infoaura_bot"
-                    print(len(message_sms_text), " length of  string")
+                    logger.debug("SMS text length: %s", len(message_sms_text))
                     if len(message_sms_text) >= 70:
-                        print('transliterate')
+                        logger.debug("Applying transliteration")
                         if divider:
                             email_text_t = transliterate.translit(email_text[i][:divider], 'uk', reversed=True)
                         else:
                             email_text_t = transliterate.translit(email_text[i], 'uk', reversed=True)
                         message_sms_text = f"{email_text_t}\nt.me/infoaura_bot"
                     else:
-                        print("no transliterate")
+                        logger.debug("No transliteration needed")
                         if divider:
                             message_sms_text = f"{email_text[i][:divider]}\nt.me/infoaura_bot"
                         else:
                             message_sms_text = f"{email_text[i]}\nt.me/infoaura_bot"
                     await sleep(60)
                     async with aiohttp.ClientSession() as session:
-                        print("Sending sms to:", email_phone[i],
-                              "with text:", message_sms_text,
-                              "length of string:", len(message_sms_text))
+                        logger.info("Sending SMS to: %s, length: %s", email_phone[i], len(message_sms_text))
                         param = {'version': 'http',
                                  'login': '380936425274',
                                  "password": "wxgjtqyo",
@@ -284,9 +277,9 @@ async def send_message_sms(phone: int = None, text: str = None):
                                  'message': f'{message_sms_text}'}
                         async with session.request('http', "https://smsukraine.com.ua/api/http.php",
                                                    params=param) as sms:
-                            print("SMS: ", await sms.text())
+                            logger.info("SMS response: %s", await sms.text())
                 except Exception as e:
-                    print(e)
+                    logger.exception("SMS send error: %s", e)
                     pass
     else:
         users = await db.select_all_users()
@@ -298,7 +291,7 @@ async def send_message_sms(phone: int = None, text: str = None):
             if int(phone) in users_id:
                 await dp.bot.send_message(int(phone), text)
                 await db.message("BOT", 10001, text, datetime.datetime.now())
-                print("Message sent via bot to:", int(phone))
+                logger.info("Message sent via bot to: %s", int(phone))
                 result = f"Message sent via bot to: {int(phone)}"
                 return result
             elif phone in users_phones:
@@ -306,26 +299,24 @@ async def send_message_sms(phone: int = None, text: str = None):
                 telegram_id = telegram_id[0]['telegram_id']
                 msg = await dp.bot.send_message(telegram_id, text)
                 await db.message("BOT", 10001, text, datetime.datetime.now())
-                print("Message sent via bot to:", telegram_id)
+                logger.info("Message sent via bot to: %s", telegram_id)
                 result = f"Message sent via bot to: {telegram_id}"
                 return result
         else:
-            print("Message sent via sms to:", phone)
+            logger.info("Sending SMS (direct) to: %s", phone)
             try:
                 message_sms_text = f"{text}\nt.me/infoaura_bot"
-                print(len(message_sms_text), " length of  string")
+                logger.debug("SMS text length: %s", len(message_sms_text))
                 if len(message_sms_text) >= 70:
-                    print('transliterate')
+                    logger.debug("Applying transliteration")
                     email_text_t = transliterate.translit(text, 'uk', reversed=True)
                     message_sms_text = f"{email_text_t}\nt.me/infoaura_bot"
                 else:
-                    print("no transliterate")
+                    logger.debug("No transliteration needed")
                     message_sms_text = f"{text}\nt.me/infoaura_bot"
                 await sleep(60)
                 async with aiohttp.ClientSession() as session:
-                    print("Sending sms to:", phone,
-                          "with text:", message_sms_text,
-                          "length of string:", len(message_sms_text))
+                    logger.info("Sending SMS to: %s, length: %s", phone, len(message_sms_text))
                     param = {'version': 'http',
                              'login': '380936425274',
                              "password": "wxgjtqyo",
@@ -335,9 +326,9 @@ async def send_message_sms(phone: int = None, text: str = None):
                              'message': f'{message_sms_text}'}
                     async with session.request('http', "https://smsukraine.com.ua/api/http.php",
                                                params=param) as sms:
-                        print("SMS: ", await sms.text())
+                        logger.info("SMS response: %s", await sms.text())
                         return "SMS: " + await sms.text()
             except Exception as e:
-                print(e)
+                logger.exception("SMS send error: %s", e)
                 return e
 

--- a/utils/notify_admins.py
+++ b/utils/notify_admins.py
@@ -4,6 +4,8 @@ from aiogram import Dispatcher
 
 from data.config import ADMINS
 
+logger = logging.getLogger(__name__)
+
 
 async def on_startup_notify(dp: Dispatcher):
     for admin in ADMINS:
@@ -11,7 +13,7 @@ async def on_startup_notify(dp: Dispatcher):
             await dp.bot.send_message(admin, "Бот Запущен, попробуй /start")
 
         except Exception as err:
-            logging.exception(err)
+            logger.exception(err)
 
 
 async def on_shutdown_notify(dp: Dispatcher):
@@ -20,4 +22,4 @@ async def on_shutdown_notify(dp: Dispatcher):
             await dp.bot.send_message(admin, "Бот выключен, взаимодействие невозможно")
 
         except Exception as err:
-            logging.exception(err)
+            logger.exception(err)


### PR DESCRIPTION
## Summary
- Replace all `print()` calls in handler and utility files with proper `logger.x()` calls
- Add `logger = logging.getLogger(__name__)` to files that were using bare `logging.x()` calls
- Normalize bare `logging.x()` to `logger.x()` for consistent, configurable logging
- Convert f-string formatting in log calls to `%s` placeholder style (lazy evaluation)

## Files changed (9)
- `handlers/users/echo.py` — 1 print → logger.debug
- `handlers/users/start.py` — 1 print → logger.debug
- `handlers/users/pay_bill.py` — 5 print + 4 bare logging → logger
- `handlers/users/panel.py` — 24 print → logger (added import logging + logger)
- `handlers/errors/error_handler.py` — 11 bare logging → logger (added logger)
- `utils/db_api/database.py` — 4 bare logging.info → logger.info
- `utils/misc/sms_message.py` — ~40 print → logger (added import logging + logger)
- `utils/misc/find_in_bill.py` — 4 bare logging.debug → logger.debug (added logger)
- `utils/notify_admins.py` — 2 bare logging.exception → logger.exception (added logger)

## Test plan
- [x] All 9 files pass `ast.parse()` syntax verification
- [x] No remaining `print()` calls in handlers/ or main utils/
- [x] No remaining bare `logging.x()` calls in handlers/ or utils/